### PR TITLE
[#50] FEAT: Item 컴포넌트 UI 생성

### DIFF
--- a/front-end/src/components/common/Item/Item.tsx
+++ b/front-end/src/components/common/Item/Item.tsx
@@ -1,0 +1,104 @@
+import { styled } from 'styled-components';
+
+import ImgBox from '../ImgBox/ImgBox';
+
+export interface saleItem {
+  id: number;
+  title: string;
+  price: number;
+  thumbnailUrl: string;
+  status: 'onSale' | 'reservation' | 'soldOut';
+  createdAt: string;
+  hits: number;
+  chatCount: number;
+  likesCount: number;
+  isLike: boolean;
+}
+
+interface ItemProps {
+  item: saleItem;
+}
+
+const Item = ({ item }: ItemProps) => {
+  const {
+    id,
+    title,
+    price,
+    thumbnailUrl,
+    status,
+    createdAt,
+    chatCount,
+    likesCount,
+    isLike,
+  } = item;
+
+  return (
+    <MyItem>
+      <ImgBox src={thumbnailUrl} />
+      <MyItemInfo>
+        <MyItemTitle>
+          <div>{title}</div>
+          {/* TODO: add more info icon */}
+          <div>...</div>
+        </MyItemTitle>
+        {/* TODO: add region */}
+        <MyItemTime>{createdAt}</MyItemTime>
+        <MyItemStatus>
+          {/* TODO: add chip component */}
+          <div>{status}</div>
+          <div>{price}원</div>
+        </MyItemStatus>
+        <MyItemSubInfo>
+          {/* TODO: add chat, likes icon with isLike prop*/}
+          <div>{chatCount}</div>
+          <div>{likesCount}</div>
+        </MyItemSubInfo>
+      </MyItemInfo>
+    </MyItem>
+  );
+};
+
+const MyItem = styled.div`
+  display: flex;
+  margin: 0 15px;
+  padding: 15px 0;
+  gap: 0 15px;
+  color: ${({ theme }) => theme.colors.neutral.text};
+  ${({ theme }) => theme.fonts.subhead}
+  border-top: 1px solid ${({ theme }) => theme.colors.neutral.border};
+`;
+
+const MyItemInfo = styled.div`
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  padding: 4px 0;
+  gap: 4px 0;
+`;
+
+const MyItemTitle = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const MyItemTime = styled.div`
+  color: ${({ theme }) => theme.colors.neutral.textWeak};
+  ${({ theme }) => theme.fonts.footnote}
+`;
+
+const MyItemStatus = styled.div`
+  display: flex;
+  gap: 0 4px;
+  font-weight: 590;
+  color: ${({ theme }) => theme.colors.neutral.textStrong};
+`;
+
+const MyItemSubInfo = styled.div`
+  height: 100%;
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-end;
+  gap: 0 4px;
+`;
+
+export default Item;

--- a/front-end/src/components/common/Item/index.ts
+++ b/front-end/src/components/common/Item/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Item';
+export type { saleItem } from './Item';

--- a/front-end/src/mock/mockData.ts
+++ b/front-end/src/mock/mockData.ts
@@ -1,0 +1,15 @@
+import { saleItem } from '@components/common/Item';
+
+export const item: saleItem = {
+  id: 1,
+  title: '베이비 북',
+  thumbnailUrl:
+    'https://secondhand-team5-bucket.s3.ap-northeast-2.amazonaws.com/icons/category/baby-book.png',
+  price: 10000,
+  createdAt: '2021-08-01',
+  status: 'onSale',
+  hits: 100,
+  chatCount: 10,
+  likesCount: 10,
+  isLike: false,
+};


### PR DESCRIPTION
- Item list에서는 user의 정보를 패치해오고 거기에 포함된 `region` data를 사용해서 상품의 지역을 표시해야 하는데 아직 user의 data가 없어, 준비되면 코드 수정 예정으로 TODO로 주석 남겼습니다. 
- Chop 컴포넌트의 부분이 준비되면 코드 수정 예정으로 TODO로 주석 남겼습니다.
- 서버에서 받아 오기로 한 svg(chat, herat)는 준비되면 코드 수정 예정으로 TODO로 주석 남겼습니다.

