### PR TITLE
[#101] FEAT: 아이템 목록 보기 v0.1

### DIFF
--- a/backend/src/main/java/com/team5/secondhand/api/item/controller/ItemController.java
+++ b/backend/src/main/java/com/team5/secondhand/api/item/controller/ItemController.java
@@ -1,0 +1,27 @@
+package com.team5.secondhand.api.item.controller;
+
+import com.team5.secondhand.api.item.dto.response.ItemList;
+import com.team5.secondhand.api.item.service.ItemService;
+import com.team5.secondhand.api.region.domain.Region;
+import com.team5.secondhand.api.region.exception.NotValidRegionException;
+import com.team5.secondhand.api.region.service.GetValidRegionsUsecase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/items")
+@RequiredArgsConstructor
+public class ItemController {
+
+    private final ItemService itemService;
+    private final GetValidRegionsUsecase getValidRegions;
+
+    @GetMapping
+    public ItemList getItemList(@RequestParam int page, @RequestParam long regionIndex) throws NotValidRegionException {
+        Map<Long, Region> regions = getValidRegions.getRegions(List.of(regionIndex));
+        return itemService.getItemList(page, regions.get(regionIndex));
+    }
+}

--- a/backend/src/main/java/com/team5/secondhand/api/item/domain/Item.java
+++ b/backend/src/main/java/com/team5/secondhand/api/item/domain/Item.java
@@ -1,0 +1,75 @@
+package com.team5.secondhand.api.item.domain;
+
+import com.team5.secondhand.api.member.domain.Member;
+import com.team5.secondhand.api.model.BaseTimeEntity;
+import com.team5.secondhand.api.region.domain.Region;
+import lombok.*;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.util.List;
+
+@Entity
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Item extends BaseTimeEntity {
+    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    @NotNull
+    @Size(min = 1, max = 45)
+    private String title;
+    private Integer price;
+    @NotNull
+    private Long category;
+    @NotNull
+    @Size(max = 300)
+    private String thumbnailUrl;
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private Status status;
+    @OneToOne
+    @JoinColumn(name = "seller_id")
+    private Member seller;
+
+    @OneToOne
+    @JoinColumn(name = "region_id")
+    private Region region;
+
+    @OneToOne
+    @JoinColumn(name = "item_counts_id")
+    private ItemCounts count;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_contents_id")
+    private ItemContents contents;
+
+    @Builder
+    private Item(Long id, String title, Integer price, Long category, String thumbnailUrl, Status status, Member seller, Region region, ItemCounts count, ItemContents contents) {
+        this.id = id;
+        this.title = title;
+        this.price = price;
+        this.category = category;
+        this.thumbnailUrl = thumbnailUrl;
+        this.status = status;
+        this.seller = seller;
+        this.region = region;
+        this.count = count;
+        this.contents = contents;
+    }
+
+    public static Item create(String title, Integer price, Long category, String thumbnailUrl, Member seller, Region region, String contents, List<ItemDetailImage> images) {
+        return Item.builder()
+                .title(title)
+                .price(price)
+                .category(category)
+                .thumbnailUrl(thumbnailUrl)
+                .status(Status.ON_SALE)
+                .seller(seller)
+                .region(region)
+                .count(ItemCounts.createRelated())
+                .contents(ItemContents.createdRelated(contents, images))
+                .build();
+    }
+}

--- a/backend/src/main/java/com/team5/secondhand/api/item/domain/ItemContents.java
+++ b/backend/src/main/java/com/team5/secondhand/api/item/domain/ItemContents.java
@@ -1,0 +1,40 @@
+package com.team5.secondhand.api.item.domain;
+
+import com.team5.secondhand.api.item.util.ImageUrlConverter;
+import lombok.*;
+
+import javax.persistence.*;
+import javax.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@ToString
+@Table(name = "item_contents")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemContents {
+
+    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private String contents;
+
+    @Size(min = 1, max = 10)
+    @Convert(converter = ImageUrlConverter.class)
+    private List<ItemDetailImage> detailImageUrl = new ArrayList<>();
+
+    @Builder
+    private ItemContents(Long id, String contents, List<ItemDetailImage> detailImageUrl) {
+        this.id = id;
+        this.contents = contents;
+        this.detailImageUrl = detailImageUrl;
+    }
+
+    public static ItemContents createdRelated(String contents, List<ItemDetailImage> images) {
+        return ItemContents.builder()
+                .contents(contents)
+                .detailImageUrl(images)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/team5/secondhand/api/item/domain/ItemCounts.java
+++ b/backend/src/main/java/com/team5/secondhand/api/item/domain/ItemCounts.java
@@ -1,0 +1,46 @@
+package com.team5.secondhand.api.item.domain;
+
+import lombok.*;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.validation.constraints.Min;
+
+@Entity
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemCounts {
+
+    private static final long INIT_COUNT_NUMBER = 0L;
+
+    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Min(0)
+    private Long hits;
+
+    @Min(0)
+    private Long likeCounts;
+
+    @Min(0)
+    private Long chatCounts;
+
+    @Builder
+    private ItemCounts(Long id, Long hits, Long likeCounts, Long chatCounts) {
+        this.id = id;
+        this.hits = hits;
+        this.likeCounts = likeCounts;
+        this.chatCounts = chatCounts;
+    }
+
+    public static ItemCounts createRelated() {
+        return ItemCounts.builder()
+                .hits(INIT_COUNT_NUMBER)
+                .likeCounts(INIT_COUNT_NUMBER)
+                .chatCounts(INIT_COUNT_NUMBER)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/team5/secondhand/api/item/domain/ItemDetailImage.java
+++ b/backend/src/main/java/com/team5/secondhand/api/item/domain/ItemDetailImage.java
@@ -1,0 +1,8 @@
+package com.team5.secondhand.api.item.domain;
+
+import lombok.Getter;
+
+@Getter
+public class ItemDetailImage {
+    private String url;
+}

--- a/backend/src/main/java/com/team5/secondhand/api/item/domain/Status.java
+++ b/backend/src/main/java/com/team5/secondhand/api/item/domain/Status.java
@@ -1,0 +1,5 @@
+package com.team5.secondhand.api.item.domain;
+
+public enum Status {
+    ON_SALE, RESERVATION, SOLD;
+}

--- a/backend/src/main/java/com/team5/secondhand/api/item/dto/response/ItemList.java
+++ b/backend/src/main/java/com/team5/secondhand/api/item/dto/response/ItemList.java
@@ -1,0 +1,20 @@
+package com.team5.secondhand.api.item.dto.response;
+
+import com.team5.secondhand.api.item.domain.Item;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import javax.validation.constraints.Size;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class ItemList {
+    private final Integer maxPage;
+    private final List<ItemSummary> items;
+
+    public static ItemList getPage(Integer maxPage, List<ItemSummary> page){
+        return new ItemList(maxPage, page);
+    }
+}

--- a/backend/src/main/java/com/team5/secondhand/api/item/dto/response/ItemSummary.java
+++ b/backend/src/main/java/com/team5/secondhand/api/item/dto/response/ItemSummary.java
@@ -1,0 +1,40 @@
+package com.team5.secondhand.api.item.dto.response;
+
+import com.team5.secondhand.api.item.domain.Item;
+import com.team5.secondhand.api.item.domain.Status;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class ItemSummary {
+    private final Long id;
+    private final String title;
+    private final String thumbnailUrl;
+    private final Instant createdAt;
+    private final Integer price;
+    private final Status status;
+    private final Long hits;
+    private final Long chatCount;
+    private final Long likeCount;
+    private final Boolean isLike;
+
+    public static ItemSummary of(Item item, Boolean isLike) {
+        return ItemSummary.builder()
+                .id(item.getId())
+                .title(item.getTitle())
+                .thumbnailUrl(item.getThumbnailUrl())
+                .createdAt(item.getCreatedAt())
+                .price(item.getPrice())
+                .status(item.getStatus())
+                .hits(item.getCount().getHits())
+                .chatCount(item.getCount().getChatCounts())
+                .likeCount(item.getCount().getLikeCounts())
+                .isLike(isLike)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/team5/secondhand/api/item/repository/ItemRepository.java
+++ b/backend/src/main/java/com/team5/secondhand/api/item/repository/ItemRepository.java
@@ -1,0 +1,14 @@
+package com.team5.secondhand.api.item.repository;
+
+import com.team5.secondhand.api.item.domain.Item;
+import com.team5.secondhand.api.region.domain.Region;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemRepository extends JpaRepository<Item, Long> {
+
+    Page<Item> findAllByRegion(Region region, Pageable pageable);
+
+    int countAllByRegion(Region region);
+}

--- a/backend/src/main/java/com/team5/secondhand/api/item/service/ItemService.java
+++ b/backend/src/main/java/com/team5/secondhand/api/item/service/ItemService.java
@@ -1,0 +1,36 @@
+package com.team5.secondhand.api.item.service;
+
+import com.team5.secondhand.api.item.domain.Item;
+import com.team5.secondhand.api.item.dto.response.ItemList;
+import com.team5.secondhand.api.item.dto.response.ItemSummary;
+import com.team5.secondhand.api.item.repository.ItemRepository;
+import com.team5.secondhand.api.region.domain.Region;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ItemService {
+
+    private final int PAGE_SIZE = 10;
+
+    private final ItemRepository itemRepository;
+
+    public ItemList getItemList(int page, Region region) {
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE, Sort.by("id").descending());
+
+        Page<Item> pageResult = itemRepository.findAllByRegion(region, pageable);
+        List<ItemSummary> items = pageResult.getContent().stream()
+                .map(i -> ItemSummary.of(i, false))
+                .collect(Collectors.toList());
+
+        return ItemList.getPage(pageResult.getTotalPages(), items);
+    }
+}

--- a/backend/src/main/java/com/team5/secondhand/api/item/util/ImageUrlConverter.java
+++ b/backend/src/main/java/com/team5/secondhand/api/item/util/ImageUrlConverter.java
@@ -1,0 +1,38 @@
+package com.team5.secondhand.api.item.util;
+
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.team5.secondhand.api.item.domain.ItemDetailImage;
+import lombok.SneakyThrows;
+
+import javax.persistence.AttributeConverter;
+import javax.validation.ValidationException;
+import java.util.InvalidPropertiesFormatException;
+
+public class ImageUrlConverter implements AttributeConverter<ItemDetailImage, String> {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    @SneakyThrows
+    public String convertToDatabaseColumn(ItemDetailImage attribute) {
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new ValidationException("이미지 URL 형식이 다릅니다.");
+        }
+    }
+
+    @Override
+    @SneakyThrows
+    public ItemDetailImage convertToEntityAttribute(String dbData) {
+        try {
+            return objectMapper.readValue(dbData, ItemDetailImage.class);
+        } catch (JsonProcessingException e) {
+            throw new ValidationException("이미지 URL 형식이 다릅니다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/team5/secondhand/api/member/controller/MemberController.java
+++ b/backend/src/main/java/com/team5/secondhand/api/member/controller/MemberController.java
@@ -94,9 +94,9 @@ public class MemberController {
     }
 
     @Operation(
-            summary = "프로필 사진 설정",
+            summary = "프로필 사진 변경",
             tags = "Members",
-            description = "사용자는 자신의 프로필 사진을 설정할 수 있다."
+            description = "사용자는 자신의 프로필 사진을 변경할 수 있다."
     )
     @PatchMapping(value = "/members/image", consumes = {"multipart/form-data"})
     public GenericResponse<ProfileImageInfo> setMemberProfile (@RequestParam Long id,
@@ -109,7 +109,7 @@ public class MemberController {
     }
 
     @Operation(
-            summary = "프로필 사진 설정",
+            summary = "사용자 지역 변경",
             tags = "Members",
             description = "사용자는 자신의 프로필 사진을 설정할 수 있다."
     )

--- a/backend/src/main/java/com/team5/secondhand/api/member/controller/MemberController.java
+++ b/backend/src/main/java/com/team5/secondhand/api/member/controller/MemberController.java
@@ -9,9 +9,10 @@ import com.team5.secondhand.api.member.dto.response.MemberDetails;
 import com.team5.secondhand.api.member.exception.ExistMemberIdException;
 import com.team5.secondhand.api.member.exception.UnauthorizedException;
 import com.team5.secondhand.api.member.service.MemberService;
-import com.team5.secondhand.api.model.Region;
+import com.team5.secondhand.api.region.domain.Region;
 import com.team5.secondhand.api.oauth.dto.UserProfile;
 import com.team5.secondhand.api.oauth.service.OAuthService;
+import com.team5.secondhand.api.region.exception.NoMainRegionException;
 import com.team5.secondhand.api.region.exception.NotValidRegionException;
 import com.team5.secondhand.api.region.service.GetValidRegionsUsecase;
 import com.team5.secondhand.global.aws.dto.response.ProfileImageInfo;
@@ -21,7 +22,6 @@ import com.team5.secondhand.global.dto.GenericResponse;
 import com.team5.secondhand.global.exception.EmptyBasedRegionException;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -43,7 +43,7 @@ public class MemberController {
             description = "사용자는 회원가입을 할 수 있다."
     )
     @PostMapping("/join")
-    public GenericResponse<Long> join (@RequestBody MemberJoin request) throws NotValidRegionException, NoMainRegionException, ExistMemberIdException {
+    public GenericResponse<Long> join (@RequestBody MemberJoin request) throws NotValidRegionException, ExistMemberIdException, NoMainRegionException {
         if (memberService.isExistMemberId(request.getMemberId(), request.getOauth())) {
             throw new ExistMemberIdException("이미 존재하는 회원 아이디입니다.");
         }
@@ -65,10 +65,10 @@ public class MemberController {
             description = "사용자는 로그인을 할 수 있다."
     )
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody MemberLogin request) throws UnauthorizedException, EmptyBasedRegionException {
+    public GenericResponse<MemberDetails> login(MemberLogin request) throws UnauthorizedException, EmptyBasedRegionException {
         MemberDetails member = memberService.login(request);
 
-        return ResponseEntity.ok(GenericResponse.send("Member login Successfully", member));
+        return GenericResponse.send("Member login Successfully", member);
     }
 
     @Operation(
@@ -85,12 +85,12 @@ public class MemberController {
     }
 
     @GetMapping("/git/login")
-    public ResponseEntity<?> getGithubUser(String code) throws UnauthorizedException, ExistMemberIdException, EmptyBasedRegionException {
+    public GenericResponse<MemberDetails> getGithubUser(String code) throws UnauthorizedException, ExistMemberIdException, EmptyBasedRegionException {
         UserProfile user = oAuthService.getGithubUser(code);
         MemberDetails member = memberService.loginByOAuth(user);
 
         //todo : jwt 생성
-        return ResponseEntity.ok(GenericResponse.send("Member login Successfully", member));
+        return GenericResponse.send("Member login Successfully", member);
     }
 
     @Operation(

--- a/backend/src/main/java/com/team5/secondhand/api/member/controller/MemberController.java
+++ b/backend/src/main/java/com/team5/secondhand/api/member/controller/MemberController.java
@@ -43,7 +43,11 @@ public class MemberController {
             description = "사용자는 회원가입을 할 수 있다."
     )
     @PostMapping("/join")
-    public GenericResponse<Long> join (@RequestBody MemberJoin request) throws NotValidRegionException {
+    public GenericResponse<Long> join (@RequestBody MemberJoin request) throws NotValidRegionException, NoMainRegionException, ExistMemberIdException {
+        if (memberService.isExistMemberId(request.getMemberId(), request.getOauth())) {
+            throw new ExistMemberIdException("이미 존재하는 회원 아이디입니다.");
+        }
+
         List<Long> ids = request.getRegions().stream()
                 .map(BasedRegionSummary::getId)
                 .collect(Collectors.toList());

--- a/backend/src/main/java/com/team5/secondhand/api/member/domain/BasedRegion.java
+++ b/backend/src/main/java/com/team5/secondhand/api/member/domain/BasedRegion.java
@@ -2,6 +2,7 @@ package com.team5.secondhand.api.member.domain;
 
 import com.team5.secondhand.api.member.dto.request.BasedRegionSummary;
 import com.team5.secondhand.api.model.Region;
+import com.team5.secondhand.api.region.exception.NoMainRegionException;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -38,12 +39,21 @@ public class BasedRegion {
         this.represented = represented;
     }
 
-    public static Map<Region, Boolean> mapping(Map<Long, Region> regions, List<BasedRegionSummary> regionSummaries) {
-       Map<Region, Boolean> basedRegions = new HashMap<>();
+    public static Map<Region, Boolean> mapping(Map<Long, Region> regions, List<BasedRegionSummary> regionSummaries) throws NoMainRegionException {
+        
+        if (regionSummaries.isEmpty()) {
+            throw new NoMainRegionException("지역을 1개 이상 설정해야 합니다.");
+        }
+
+        Map<Region, Boolean> basedRegions = new HashMap<>();
 
         for (BasedRegionSummary regionSummary : regionSummaries) {
             Region region = regions.get(regionSummary.getId());
-            basedRegions.put(region, regionSummary.getIsRepresent());
+            basedRegions.put(region, regionSummary.getOnFocus());
+        }
+
+        if (!basedRegions.containsValue(true)) {
+            throw new NoMainRegionException("대표 지역이 지정되어 있지 않습니다.");
         }
 
         return basedRegions;

--- a/backend/src/main/java/com/team5/secondhand/api/member/domain/BasedRegion.java
+++ b/backend/src/main/java/com/team5/secondhand/api/member/domain/BasedRegion.java
@@ -1,7 +1,7 @@
 package com.team5.secondhand.api.member.domain;
 
 import com.team5.secondhand.api.member.dto.request.BasedRegionSummary;
-import com.team5.secondhand.api.model.Region;
+import com.team5.secondhand.api.region.domain.Region;
 import com.team5.secondhand.api.region.exception.NoMainRegionException;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/backend/src/main/java/com/team5/secondhand/api/member/dto/request/BasedRegionSummary.java
+++ b/backend/src/main/java/com/team5/secondhand/api/member/dto/request/BasedRegionSummary.java
@@ -5,5 +5,5 @@ import lombok.Getter;
 @Getter
 public class BasedRegionSummary {
     private Long id;
-    private Boolean isRepresent;
+    private Boolean onFocus;
 }

--- a/backend/src/main/java/com/team5/secondhand/api/member/dto/request/MemberJoin.java
+++ b/backend/src/main/java/com/team5/secondhand/api/member/dto/request/MemberJoin.java
@@ -3,12 +3,15 @@ package com.team5.secondhand.api.member.dto.request;
 import com.team5.secondhand.api.member.domain.Member;
 import com.team5.secondhand.api.member.domain.Oauth;
 import lombok.Data;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.util.List;
 
-@Data
+@Getter
+@RequiredArgsConstructor
 public class MemberJoin {
 
     @NotNull

--- a/backend/src/main/java/com/team5/secondhand/api/member/dto/request/MemberJoin.java
+++ b/backend/src/main/java/com/team5/secondhand/api/member/dto/request/MemberJoin.java
@@ -18,12 +18,14 @@ public class MemberJoin {
     private final String profileImgUrl;
     @Size(min = 1, max = 2)
     private final List<BasedRegionSummary> regions;
+    @NotNull
+    private final Oauth oauth;
 
     public Member toMember() {
         return Member.builder()
                 .memberId(memberId)
                 .profileImgUrl(profileImgUrl)
-                .oauth(Oauth.NONE)
+                .oauth(oauth)
                 .build();
     }
 }

--- a/backend/src/main/java/com/team5/secondhand/api/member/dto/request/MemberProfileImageUpdate.java
+++ b/backend/src/main/java/com/team5/secondhand/api/member/dto/request/MemberProfileImageUpdate.java
@@ -1,4 +1,10 @@
 package com.team5.secondhand.api.member.dto.request;
 
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
 public class MemberProfileImageUpdate {
+    private Long id;
+    private MultipartFile profileImage;
 }

--- a/backend/src/main/java/com/team5/secondhand/api/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/team5/secondhand/api/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.team5.secondhand.api.member.repository;
 
 import com.team5.secondhand.api.member.domain.Member;
+import com.team5.secondhand.api.member.domain.Oauth;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -17,7 +18,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     int updateMemberProfileImage(@Param("id") Long id,
                                  @Param("url") String url);
 
-    boolean existsByMemberId(String memberId);
-
     Optional<Member> findByMemberId(String memberId);
+    boolean existsByMemberIdAndOauth(String memberId, Oauth oauth);
 }

--- a/backend/src/main/java/com/team5/secondhand/api/member/service/JoinService.java
+++ b/backend/src/main/java/com/team5/secondhand/api/member/service/JoinService.java
@@ -2,7 +2,7 @@ package com.team5.secondhand.api.member.service;
 
 import com.team5.secondhand.api.member.dto.request.MemberJoin;
 import com.team5.secondhand.api.member.exception.ExistMemberIdException;
-import com.team5.secondhand.api.model.Region;
+import com.team5.secondhand.api.region.domain.Region;
 
 import java.util.Map;
 

--- a/backend/src/main/java/com/team5/secondhand/api/member/service/MemberService.java
+++ b/backend/src/main/java/com/team5/secondhand/api/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.team5.secondhand.api.member.service;
 
 import com.team5.secondhand.api.member.domain.BasedRegion;
 import com.team5.secondhand.api.member.domain.Member;
+import com.team5.secondhand.api.member.domain.Oauth;
 import com.team5.secondhand.api.member.dto.request.MemberJoin;
 import com.team5.secondhand.api.member.dto.request.MemberLogin;
 import com.team5.secondhand.api.member.dto.response.MemberDetails;
@@ -64,8 +65,8 @@ public class MemberService implements JoinService {
         return MemberDetails.fromMember(member);
     }
 
-    public Boolean isExistMemberId(String memberId) throws ExistMemberIdException {
-        return memberRepository.existsByMemberId(memberId);
+    public Boolean isExistMemberId(String memberId, Oauth oauth) throws ExistMemberIdException {
+        return memberRepository.existsByMemberIdAndOauth(memberId, oauth);
     }
 
     @Transactional

--- a/backend/src/main/java/com/team5/secondhand/api/member/service/MemberService.java
+++ b/backend/src/main/java/com/team5/secondhand/api/member/service/MemberService.java
@@ -10,7 +10,7 @@ import com.team5.secondhand.api.member.exception.ExistMemberIdException;
 import com.team5.secondhand.api.member.exception.UnauthorizedException;
 import com.team5.secondhand.api.member.repository.MemberBasedRegionRepository;
 import com.team5.secondhand.api.member.repository.MemberRepository;
-import com.team5.secondhand.api.model.Region;
+import com.team5.secondhand.api.region.domain.Region;
 import com.team5.secondhand.api.oauth.dto.UserProfile;
 import com.team5.secondhand.global.exception.EmptyBasedRegionException;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/team5/secondhand/api/model/BaseTimeEntity.java
+++ b/backend/src/main/java/com/team5/secondhand/api/model/BaseTimeEntity.java
@@ -20,9 +20,9 @@ import java.time.Instant;
 public class BaseTimeEntity {
 
     @CreatedDate
-    private Instant createdDateTime;
+    private Instant createdAt;
 
     @LastModifiedDate
-    private Instant updatedDateTime;
+    private Instant updatedAt;
 
 }

--- a/backend/src/main/java/com/team5/secondhand/api/region/domain/Region.java
+++ b/backend/src/main/java/com/team5/secondhand/api/region/domain/Region.java
@@ -1,4 +1,4 @@
-package com.team5.secondhand.api.model;
+package com.team5.secondhand.api.region.domain;
 
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/backend/src/main/java/com/team5/secondhand/api/region/exception/NoMainRegionException.java
+++ b/backend/src/main/java/com/team5/secondhand/api/region/exception/NoMainRegionException.java
@@ -1,0 +1,7 @@
+package com.team5.secondhand.api.region.exception;
+
+public class NoMainRegionException extends RegionServiceException {
+    public NoMainRegionException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/team5/secondhand/api/region/exception/NotValidRegionException.java
+++ b/backend/src/main/java/com/team5/secondhand/api/region/exception/NotValidRegionException.java
@@ -1,6 +1,6 @@
 package com.team5.secondhand.api.region.exception;
 
-public class NotValidRegionException extends Exception {
+public class NotValidRegionException extends RegionServiceException {
     public NotValidRegionException(String message) {
         super(message);
     }

--- a/backend/src/main/java/com/team5/secondhand/api/region/exception/RegionServiceException.java
+++ b/backend/src/main/java/com/team5/secondhand/api/region/exception/RegionServiceException.java
@@ -1,0 +1,7 @@
+package com.team5.secondhand.api.region.exception;
+
+public class RegionServiceException extends Exception{
+    public RegionServiceException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/team5/secondhand/api/region/repository/RegionRepository.java
+++ b/backend/src/main/java/com/team5/secondhand/api/region/repository/RegionRepository.java
@@ -1,6 +1,6 @@
 package com.team5.secondhand.api.region.repository;
 
-import com.team5.secondhand.api.model.Region;
+import com.team5.secondhand.api.region.domain.Region;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/backend/src/main/java/com/team5/secondhand/api/region/service/GetValidRegionsUsecase.java
+++ b/backend/src/main/java/com/team5/secondhand/api/region/service/GetValidRegionsUsecase.java
@@ -1,6 +1,6 @@
 package com.team5.secondhand.api.region.service;
 
-import com.team5.secondhand.api.model.Region;
+import com.team5.secondhand.api.region.domain.Region;
 import com.team5.secondhand.api.region.exception.NotValidRegionException;
 
 import java.util.List;

--- a/backend/src/main/java/com/team5/secondhand/api/region/service/RegionService.java
+++ b/backend/src/main/java/com/team5/secondhand/api/region/service/RegionService.java
@@ -1,6 +1,6 @@
 package com.team5.secondhand.api.region.service;
 
-import com.team5.secondhand.api.model.Region;
+import com.team5.secondhand.api.region.domain.Region;
 import com.team5.secondhand.api.region.exception.NotValidRegionException;
 import com.team5.secondhand.api.region.repository.RegionRepository;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/team5/secondhand/global/aws/controller/ImageHostController.java
+++ b/backend/src/main/java/com/team5/secondhand/global/aws/controller/ImageHostController.java
@@ -1,0 +1,29 @@
+package com.team5.secondhand.global.aws.controller;
+
+import com.team5.secondhand.global.aws.dto.response.ProfileImageInfo;
+import com.team5.secondhand.global.aws.exception.ImageHostingException;
+import com.team5.secondhand.global.aws.service.ImageHostService;
+import com.team5.secondhand.global.dto.GenericResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+public class ImageHostController {
+
+    private final ImageHostService imageHostService;
+
+    @Operation(
+            summary = "프로필 사진 업로드",
+            tags = "Image",
+            description = "사용자는 자신의 프로필 사진을 업로드할 수 있다."
+    )
+    @PostMapping(value = "/profile/image", consumes = {"multipart/form-data"})
+    public GenericResponse<ProfileImageInfo> setMemberProfile (@RequestPart MultipartFile profile) throws ImageHostingException {
+        ProfileImageInfo profileImageInfo = imageHostService.uploadMemberProfileImage(profile);
+        return GenericResponse.send("Member update profile image Successfully", profileImageInfo);
+    }
+
+}

--- a/backend/src/main/java/com/team5/secondhand/global/aws/controller/ImageHostController.java
+++ b/backend/src/main/java/com/team5/secondhand/global/aws/controller/ImageHostController.java
@@ -23,7 +23,7 @@ public class ImageHostController {
     @PostMapping(value = "/profile/image", consumes = {"multipart/form-data"})
     public GenericResponse<ProfileImageInfo> setMemberProfile (@RequestPart MultipartFile profile) throws ImageHostingException {
         ProfileImageInfo profileImageInfo = imageHostService.uploadMemberProfileImage(profile);
-        return GenericResponse.send("Member update profile image Successfully", profileImageInfo);
+        return GenericResponse.send("Member upload profile image Successfully", profileImageInfo);
     }
 
 }

--- a/backend/src/main/java/com/team5/secondhand/global/aws/service/ImageHostService.java
+++ b/backend/src/main/java/com/team5/secondhand/global/aws/service/ImageHostService.java
@@ -43,7 +43,7 @@ public class ImageHostService implements ProfileUploadUsecase{
     public ProfileImageInfo uploadMemberProfileImage(MultipartFile file) throws ImageHostingException {
         String imageUrl = "";
 
-        if (file.getSize() > 1e+8) {
+        if (file.getSize() > (1e+8*2)) {
             throw new TooLargeImageException("사진 용량이 10MB를 초과해 업로드에 실패하였습니다.");
         }
 

--- a/backend/src/main/java/com/team5/secondhand/global/aws/service/ProfileUploadUsecase.java
+++ b/backend/src/main/java/com/team5/secondhand/global/aws/service/ProfileUploadUsecase.java
@@ -1,6 +1,5 @@
 package com.team5.secondhand.global.aws.service;
 
-import com.team5.secondhand.global.aws.dto.request.ProfileImageUpload;
 import com.team5.secondhand.global.aws.dto.response.ProfileImageInfo;
 import com.team5.secondhand.global.aws.exception.ImageHostingException;
 import org.springframework.web.multipart.MultipartFile;

--- a/backend/src/main/java/com/team5/secondhand/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/team5/secondhand/global/exception/GlobalExceptionHandler.java
@@ -6,8 +6,6 @@ import com.team5.secondhand.global.aws.exception.TooLargeImageException;
 import com.team5.secondhand.global.dto.ErrorResponse;
 import com.team5.secondhand.global.dto.ErrorResponseWithBody;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;

--- a/backend/src/main/java/com/team5/secondhand/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/team5/secondhand/global/exception/GlobalExceptionHandler.java
@@ -6,12 +6,15 @@ import com.team5.secondhand.global.aws.exception.TooLargeImageException;
 import com.team5.secondhand.global.dto.ErrorResponse;
 import com.team5.secondhand.global.dto.ErrorResponseWithBody;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
+@Order(Ordered.LOWEST_PRECEDENCE)
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 

--- a/backend/src/main/resources/db/schema.sql
+++ b/backend/src/main/resources/db/schema.sql
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS `secondhand-db`.`member`
     `profile_img_url` VARCHAR(300) NULL,
     `oauth`           ENUM('GITHUB', 'NONE'),
     PRIMARY KEY (`id`),
-    UNIQUE INDEX `memberId_UNIQUE` (`member_id` ASC) VISIBLE
+    INDEX `memberId_UNIQUE` (`member_id` ASC) VISIBLE
 )
     ENGINE = InnoDB;
 

--- a/backend/src/main/resources/db/schema.sql
+++ b/backend/src/main/resources/db/schema.sql
@@ -73,8 +73,8 @@ CREATE TABLE IF NOT EXISTS `secondhand-db`.`item_counts`
 (
     `id`          BIGINT      NOT NULL AUTO_INCREMENT,
     `hits`        BIGINT      NOT NULL,
-    `like_counts` VARCHAR(45) NOT NULL,
-    `chat_counts` VARCHAR(45) NOT NULL,
+    `like_counts` BIGINT NOT NULL,
+    `chat_counts` BIGINT NOT NULL,
     PRIMARY KEY (`id`)
 )
     ENGINE = InnoDB;
@@ -89,7 +89,7 @@ CREATE TABLE IF NOT EXISTS `secondhand-db`.`item_contents`
 (
     `id`               BIGINT        NOT NULL AUTO_INCREMENT,
     `contents`         TEXT          NULL,
-    `detail_image_url` VARCHAR(2000) NULL,
+    `detail_image_url` VARCHAR(3000) NULL,
     PRIMARY KEY (`id`)
 )
     ENGINE = InnoDB;


### PR DESCRIPTION
## 구현 사항
- 페이지와 지역 요청시 10개씩 item 데이터를 반환한다.

## 업데이트 하고싶은 사항
- 

## 테스트시 주의사항
- 회원의 좋아요 여부는 `관심 상품` 도메인이 