### PR TITLE
[#53] Layout 반응형 value 수정

### DIFF
--- a/front-end/src/components/common/NavBar/NavBar.tsx
+++ b/front-end/src/components/common/NavBar/NavBar.tsx
@@ -13,9 +13,9 @@ const NavBar = ({ left, center, right, children }: NavBarProps) => {
   return (
     <MyNavBar>
       <MyNavBarTitle>
-        {left}
+        <MyNavBarLeftTitle>{left}</MyNavBarLeftTitle>
         <MyNavBarCenter>{center}</MyNavBarCenter>
-        {right}
+        {right && <MyNavBarRightTitle>{right}</MyNavBarRightTitle>}
       </MyNavBarTitle>
       {children && <MyNavBarChildren>{children}</MyNavBarChildren>}
     </MyNavBar>
@@ -27,24 +27,32 @@ const MyNavBar = styled.div`
   top: 0;
   background-color: ${({ theme }) => theme.colors.neutral.backgroundBlur};
   backdrop-filter: blur(3px);
-
   border-bottom: 1px solid ${({ theme }) => theme.colors.neutral.border};
 `;
 
 const MyNavBarTitle = styled.div`
-  display: flex;
-  justify-content: space-between;
+  display: grid;
   align-items: flex-end;
-  min-height: 66px;
+  grid-template-columns: 1fr 1fr 1fr;
+  height: 10vh;
   padding: 10px 10px;
-  ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.neutral.textWeak};
+  ${({ theme }) => theme.fonts.body};
   /* border-radius: 10px 10px 0px 0px; */ // TODO: 팝업 애니메이션 적용시 필요함
 `;
 
-const MyNavBarCenter = styled.div`
+const MyNavBarLeftTitle = styled.p`
+  text-align: left;
+`;
+
+const MyNavBarRightTitle = styled.p`
+  text-align: right;
+`;
+
+const MyNavBarCenter = styled.p`
   font-weight: 600;
   color: ${({ theme }) => theme.colors.neutral.textStrong};
+  text-align: center;
 `;
 
 const MyNavBarChildren = styled.div`

--- a/front-end/src/components/common/TabBar/MainTabBar.tsx
+++ b/front-end/src/components/common/TabBar/MainTabBar.tsx
@@ -50,7 +50,7 @@ const MainTabBar = ({ userId }: MainTabBarProps) => {
       id: 5,
       icon: 'person',
       label: '내 계정',
-      path: '/members',
+      path: '/login',
     },
   ];
 

--- a/front-end/src/components/common/TabBar/TabBar.tsx
+++ b/front-end/src/components/common/TabBar/TabBar.tsx
@@ -13,8 +13,9 @@ const TabBar = ({ className, children }: TabBarProps) => {
 
 const MyTabBar = styled.div`
   display: flex;
-  position: sticky;
+  position: fixed;
   bottom: 0;
+  width: 100%;
   height: 83px;
   flex-direction: row;
   justify-content: space-between;

--- a/front-end/src/pages/Layout.tsx
+++ b/front-end/src/pages/Layout.tsx
@@ -2,7 +2,7 @@ import { Outlet } from 'react-router-dom';
 
 import MainTabBar from '@common/TabBar/MainTabBar';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 const MobileLayout = () => {
   return (

--- a/front-end/src/pages/Layout.tsx
+++ b/front-end/src/pages/Layout.tsx
@@ -1,6 +1,5 @@
 import { Outlet } from 'react-router-dom';
 
-import NavBar from '@common/NavBar';
 import MainTabBar from '@common/TabBar/MainTabBar';
 
 import styled from 'styled-components';
@@ -8,7 +7,6 @@ import styled from 'styled-components';
 const MobileLayout = () => {
   return (
     <MyMobileLayout>
-      <NavBar>this is header!</NavBar>
       <Outlet />
       <MainTabBar userId={1} />
     </MyMobileLayout>
@@ -16,10 +14,8 @@ const MobileLayout = () => {
 };
 
 const MyMobileLayout = styled.div`
-  position: relative;
-  width: 393px;
-  height: 852px;
-  margin: 0 auto;
+  width: 100vw;
+  height: 100vh;
   background-color: #fff;
   overflow: auto;
 `;


### PR DESCRIPTION
- height: 100vh 로 설정하여 크기에 상관없이 높이를 꽉 차게 하였습니다.
- 추후 width의 경우 모바일과 테블릿은 꽉차게 보이며 웹의 경우 min-width를 설정하여 background 처리할 예정입니다.
- 따라서 각 페이지별로 콘텐츠의 높이 수정이 필요합니다.
- Navigation Bar의 경우 각 페이지별로 필요한 형태가 달라 MobileLayout 컴포넌트에서 제외하였습니다.
- 홈화면의 경우 탭바의 높이 83px을 제외한 나머지 값을 높이로 수정해야하며, 현재 로그인 페이지에 적용완료하였습니다.

![반응형](https://github.com/masters2023-2nd-project-05/second-hand/assets/107349637/a54c900c-2afa-4e7c-a10b-09fcc3401913)
