### PR TITLE
FEAT: authority Interceptor

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:11-alpine
 
 ARG JAR_FILE=./backend/build/libs/*-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar

--- a/backend/src/main/java/com/team5/secondhand/api/member/controller/MemberController.java
+++ b/backend/src/main/java/com/team5/secondhand/api/member/controller/MemberController.java
@@ -57,12 +57,12 @@ public class MemberController {
             joinPlatform = Oauth.GITHUB;
             memberService.checkDataCorruption(request, tempMember);
             memberService.isExistMemberId(request.getMemberId(), joinPlatform);
+            session.invalidate();
         }
 
         Map<Region, Boolean> basedRegions = BasedRegion.mapping(validRegions.getRegions(request.getRegionsId()), request.getRegions());
         Long joinedId = memberService.join(request, basedRegions, joinPlatform);
 
-        session.invalidate();
         return GenericResponse.send("Member joined Successfully", joinedId);
     }
 

--- a/backend/src/main/java/com/team5/secondhand/api/member/dto/request/MemberJoin.java
+++ b/backend/src/main/java/com/team5/secondhand/api/member/dto/request/MemberJoin.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -31,6 +32,7 @@ public class MemberJoin {
         return Member.builder()
                 .memberId(memberId)
                 .profileImgUrl(profileImgUrl)
+                .regions(new ArrayList<>())
                 .build();
     }
 }

--- a/backend/src/main/java/com/team5/secondhand/global/auth/interceptor/AuthorityInterceptor.java
+++ b/backend/src/main/java/com/team5/secondhand/global/auth/interceptor/AuthorityInterceptor.java
@@ -1,0 +1,27 @@
+package com.team5.secondhand.global.auth.interceptor;
+
+import com.team5.secondhand.api.member.dto.response.MemberDetails;
+import com.team5.secondhand.global.jwt.util.JwtProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.security.sasl.AuthenticationException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class AuthorityInterceptor implements HandlerInterceptor {
+    public static final String[] LOGIN_ESSENTIAL = {"/members/**", "/logout"};
+    public static final String[] LOGIN_INESSENTIAL = {"/", "/join", "/git/**", "/login"};
+
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        MemberDetails loginMember = (MemberDetails) request.getAttribute("loginMember");
+        if (loginMember == null) {
+            throw new AuthenticationException("로그인이 필요한 기능입니다.");
+        }
+        return true;
+    }
+
+
+}

--- a/backend/src/main/java/com/team5/secondhand/global/config/WebConfig.java
+++ b/backend/src/main/java/com/team5/secondhand/global/config/WebConfig.java
@@ -1,11 +1,20 @@
 package com.team5.secondhand.global.config;
 
+import com.team5.secondhand.global.auth.interceptor.AuthorityInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new AuthorityInterceptor())
+                .addPathPatterns(AuthorityInterceptor.LOGIN_ESSENTIAL)
+                .excludePathPatterns(AuthorityInterceptor.LOGIN_INESSENTIAL);
+    }
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {

--- a/backend/src/main/java/com/team5/secondhand/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/team5/secondhand/global/exception/GlobalExceptionHandler.java
@@ -11,13 +11,16 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import javax.security.sasl.AuthenticationException;
+
 @Slf4j
 @Order(Ordered.LOWEST_PRECEDENCE)
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-    @ExceptionHandler(TooLargeImageException.class)
-    @ResponseStatus(HttpStatus.PAYLOAD_TOO_LARGE)
-    public ErrorResponse handleTooLargeImageException(TooLargeImageException e) {
+
+    @ExceptionHandler(AuthenticationException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ErrorResponse handleAuthenticationException(AuthenticationException e) {
         return ErrorResponse.occur(e);
     }
 


### PR DESCRIPTION
## 구현사항
- 로그인이 필요한 페이지 interceptor 구현

## 업데이트 할 사항
- 로그인이 필요한 페이지 추가

## 주의사항
```java
    public static final String[] LOGIN_ESSENTIAL = {"/members/**", "/logout"}; // 로그인이 필요한 api prefix
    public static final String[] LOGIN_INESSENTIAL = {"/", "/join", "/git/**", "/login"}; // 로그인이 필요하지 않은 api prefix
```
- 앞으로의 테스트 시 로그인 상태를 영향받은 API 가 생겼습니다.

## Refs.
- #137 
- #71 