### PR TITLE
REFACTOR: 이미지 등록 로직 수정

### DIFF
--- a/backend/src/main/java/com/team5/secondhand/api/item/controller/ItemController.java
+++ b/backend/src/main/java/com/team5/secondhand/api/item/controller/ItemController.java
@@ -1,9 +1,11 @@
 package com.team5.secondhand.api.item.controller;
 
 import com.team5.secondhand.api.item.domain.Item;
+import com.team5.secondhand.api.item.domain.ItemDetailImage;
 import com.team5.secondhand.api.item.dto.request.ItemFilteredSlice;
 import com.team5.secondhand.api.item.dto.request.ItemImage;
 import com.team5.secondhand.api.item.dto.request.ItemPost;
+import com.team5.secondhand.api.item.dto.request.ItemPostWithUrl;
 import com.team5.secondhand.api.item.dto.response.ItemDetail;
 import com.team5.secondhand.api.item.dto.response.ItemList;
 import com.team5.secondhand.api.item.exception.ExistItemException;
@@ -69,16 +71,16 @@ public class ItemController {
             tags = "Items",
             description = "사용자는 새로운 상품을 등록할 수 있다."
     )
-    @PostMapping
+    @PostMapping(consumes = {"multipart/form-data"})
     public GenericResponse<Long> postItem(@RequestAttribute("loginMember") MemberDetails loginMember, @RequestBody ItemPost itemPost) throws ExistMemberIdException, NotValidRegionException, ImageHostException {
         Member seller = memberService.findByid(loginMember.getId());
         Region region = getValidRegions.getRegion(itemPost.getRegion());
+        List<ItemDetailImage> itemDetailImages = detailImageUpload.uploadItemDetailImages(itemPost.getImages());
 
-        Item item = itemPost.toEntity();
-        String firstImageUrl = item.getFirstDetailImage().getUrl();
+        Item item = itemPost.toEntity(itemDetailImages);
+        String thumbnailUrl = thumbnailImageUpload.uploadItemThumbnailImage(item);
 
-        String thumbnailUrl = thumbnailImageUpload.uploadItemThumbnailImage(firstImageUrl);
-        Long id = itemService.postItem(item, thumbnailUrl, seller, region);
+        Long id = itemService.postItem(item, seller, region);
 
         return GenericResponse.send("상품 등록이 완료되었습니다.", id);
     }

--- a/backend/src/main/java/com/team5/secondhand/api/item/controller/ItemController.java
+++ b/backend/src/main/java/com/team5/secondhand/api/item/controller/ItemController.java
@@ -89,12 +89,12 @@ public class ItemController {
             description = "사용자는 상품 정보를 수정할 수 있다."
     )
     @PutMapping("/{id}")
-    public GenericResponse<Long> updateItem(@PathVariable Long id, @RequestAttribute MemberDetails loginMember, @RequestBody ItemPost itemPost) throws ExistMemberIdException, NotValidRegionException, ExistItemException, ExistItemException {
+    public GenericResponse<Long> updateItem(@PathVariable Long id, @RequestAttribute MemberDetails loginMember, @RequestBody ItemPostWithUrl itemPost) throws ExistMemberIdException, NotValidRegionException, ExistItemException, ExistItemException {
         //의문: seller, region이 기존이랑 달라져도 되나?
         Member seller = memberService.findByid(loginMember.getId());
         Region region = getValidRegions.getRegion(itemPost.getRegion());
         //TODO: order 1 썸네일 이미지 서비스
-        String thumbanilUrl = itemPost.getImages().stream().filter(i -> i.getOrder() == 1).map(ItemImage::getUrl).toString();
+        String thumbanilUrl = itemPost.getImages().get(0).getUrl();
         itemService.updateItem(id, itemPost, thumbanilUrl);
 
         return GenericResponse.send("상품 수정이 완료되었습니다.", id);

--- a/backend/src/main/java/com/team5/secondhand/api/item/controller/ItemController.java
+++ b/backend/src/main/java/com/team5/secondhand/api/item/controller/ItemController.java
@@ -56,7 +56,7 @@ public class ItemController {
     @Operation(
             summary = "상품 상세 이미지 업로드",
             tags = "Items",
-            description = "사용자는 상품 이미지를 첨부할 수 있다."
+            description = "사용자는 상품 이미지를 추가로 첨부할 수 있다."
     )
     @PostMapping(value = "/image", consumes = {"multipart/form-data"})
     public GenericResponse<ImageInfo> uploadItemImage(@ModelAttribute ItemImageUpload file) throws ImageHostException {

--- a/backend/src/main/java/com/team5/secondhand/api/item/domain/Item.java
+++ b/backend/src/main/java/com/team5/secondhand/api/item/domain/Item.java
@@ -1,7 +1,7 @@
 package com.team5.secondhand.api.item.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.team5.secondhand.api.item.dto.request.ItemPost;
+import com.team5.secondhand.api.item.dto.request.ItemPostWithUrl;
 import com.team5.secondhand.api.member.domain.Member;
 import com.team5.secondhand.api.model.BaseTimeEntity;
 import com.team5.secondhand.api.region.domain.Region;
@@ -62,19 +62,7 @@ public class Item extends BaseTimeEntity {
         this.contents = contents;
     }
 
-    public static Item create(ItemPost newItem, String thumbanilUrl, Member seller, Region region) {
-        return Item.builder()
-                .title(newItem.getTitle())
-                .price(newItem.getPrice())
-                .category(newItem.getCategory())
-                .thumbnailUrl(thumbanilUrl)
-                .status(Status.ON_SALE).seller(seller)
-                .region(region).count(ItemCounts.createRelated())
-                .contents(ItemContents.createdRelated(newItem.getContents(), newItem.getImages()))
-                .build();
-    }
-
-    public Item updatePost(ItemPost itemPost, String thumbanilUrl) {
+    public Item updatePost(ItemPostWithUrl itemPost, String thumbanilUrl) {
         this.title = itemPost.getTitle();
         this.category = itemPost.getCategory();
         this.price = itemPost.getPrice();
@@ -97,6 +85,12 @@ public class Item extends BaseTimeEntity {
 
     public Item updateThumbnail(String thumbanilUrl) {
         this.thumbnailUrl = thumbanilUrl;
+        return this;
+    }
+
+    public Item owned(Member seller, Region region) {
+        this.seller = seller;
+        this.region = region;
         return this;
     }
 }

--- a/backend/src/main/java/com/team5/secondhand/api/item/domain/ItemContents.java
+++ b/backend/src/main/java/com/team5/secondhand/api/item/domain/ItemContents.java
@@ -34,11 +34,7 @@ public class ItemContents {
         this.detailImageUrl = detailImageUrl;
     }
 
-    public static ItemContents createdRelated(String contents, List<ItemImage> itemImages) {
-        List<ItemDetailImage> images = itemImages.stream().map(ItemImage::toEntity)
-                .sorted(Comparator.comparing(ItemDetailImage::getOrder))
-                .collect(Collectors.toList());
-
+    public static ItemContents createdRelated(String contents, List<ItemDetailImage> images) {
         return ItemContents.builder()
                 .contents(contents)
                 .detailImageUrl(images)

--- a/backend/src/main/java/com/team5/secondhand/api/item/domain/ItemDetailImage.java
+++ b/backend/src/main/java/com/team5/secondhand/api/item/domain/ItemDetailImage.java
@@ -1,6 +1,5 @@
 package com.team5.secondhand.api.item.domain;
 
-import com.team5.secondhand.api.item.dto.request.ItemImage;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,9 +11,16 @@ public class ItemDetailImage {
     private String url;
 
     @Builder
-    public ItemDetailImage(int order, String url) {
+    private ItemDetailImage(int order, String url) {
         this.order = order;
         this.url = url;
+    }
+
+    public static ItemDetailImage create (int order, String url) {
+        return ItemDetailImage.builder()
+                .order(order)
+                .url(url)
+                .build();
     }
 
 }

--- a/backend/src/main/java/com/team5/secondhand/api/item/dto/request/ItemPostWithUrl.java
+++ b/backend/src/main/java/com/team5/secondhand/api/item/dto/request/ItemPostWithUrl.java
@@ -1,40 +1,41 @@
 package com.team5.secondhand.api.item.dto.request;
 
-import com.team5.secondhand.api.item.domain.*;
-import lombok.Builder;
+import com.team5.secondhand.api.item.domain.Item;
+import com.team5.secondhand.api.item.domain.ItemContents;
+import com.team5.secondhand.api.item.domain.ItemCounts;
+import com.team5.secondhand.api.item.domain.Status;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 import java.util.List;
+import java.util.Optional;
 
 @Getter
 @RequiredArgsConstructor
-public class ItemPost {
+public class ItemPostWithUrl {
     @NotNull
     private final String title;
-    @Size(max = 2000000)
     private final String contents;
     @NotNull
     private final Long category;
     @NotNull
     private final Long region;
-    @Size(min = 0)
     private final int price;
     @NotNull
-    @Size(min = 1, max = 10)
-    private final List<MultipartFile> images;
+    private final List<ItemImage> images;
 
-    public Item toEntity(List<ItemDetailImage> images) {
+    public Optional<ItemImage> getFirstImageUrl() {
+        return images.stream().sorted().findAny();
+    }
+
+    public Item toEntity() {
         return Item.builder()
                 .title(title)
-                .price(price)
                 .category(category)
+                .price(price)
                 .status(Status.ON_SALE)
                 .count(ItemCounts.createRelated())
-                .contents(ItemContents.createdRelated(contents, images))
                 .build();
     }
 }

--- a/backend/src/main/java/com/team5/secondhand/api/item/service/ItemService.java
+++ b/backend/src/main/java/com/team5/secondhand/api/item/service/ItemService.java
@@ -1,7 +1,7 @@
 package com.team5.secondhand.api.item.service;
 
 import com.team5.secondhand.api.item.domain.Item;
-import com.team5.secondhand.api.item.dto.request.ItemPost;
+import com.team5.secondhand.api.item.dto.request.ItemPostWithUrl;
 import com.team5.secondhand.api.item.domain.Status;
 import com.team5.secondhand.api.item.dto.request.ItemFilteredSlice;
 import com.team5.secondhand.api.item.dto.response.ItemDetail;
@@ -45,14 +45,12 @@ public class ItemService {
         return ItemList.getSlice(pageResult.getNumber(), pageResult.hasPrevious(), pageResult.hasNext(), items);
     }
 
-    public Long postItem(Item itemPost, String thumbanilUrl, Member member, Region region) {
-        Item item = itemPost.sellerInfo(member, region)
-                            .updateThumbnail(thumbanilUrl);
-        itemRepository.save(item);
+    public Long postItem(Item item, Member seller, Region region) {
+        itemRepository.save(item.owned(seller, region));
         return item.getId();
     }
 
-    public void updateItem(Long id, ItemPost itemPost, String thumbanilUrl) throws ExistItemException {
+    public void updateItem(Long id, ItemPostWithUrl itemPost, String thumbanilUrl) throws ExistItemException {
         Item item = itemRepository.findById(id).orElseThrow(() -> new ExistItemException("없는 아이템입니다."));
         Item newItem = item.updatePost(itemPost, thumbanilUrl);
         itemRepository.save(newItem);

--- a/backend/src/main/java/com/team5/secondhand/global/aws/service/ImageHostService.java
+++ b/backend/src/main/java/com/team5/secondhand/global/aws/service/ImageHostService.java
@@ -4,6 +4,9 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.team5.secondhand.api.item.domain.Item;
+import com.team5.secondhand.api.item.domain.ItemDetailImage;
+import com.team5.secondhand.api.item.dto.request.ItemImage;
 import com.team5.secondhand.global.aws.domain.Directory;
 import com.team5.secondhand.global.aws.domain.Type;
 import com.team5.secondhand.global.aws.dto.response.ImageInfo;
@@ -20,7 +23,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.UUID;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -81,7 +84,8 @@ public class ImageHostService implements ProfileUpload, ItemDetailImageUpload, I
     }
 
     @Override
-    public String uploadItemThumbnailImage(String url) throws ImageHostException {
+    public String uploadItemThumbnailImage(Item item) throws ImageHostException {
+        String url = item.getFirstDetailImage().getUrl();
         String key = getKey(url);
         String newKey = key.replace(Directory.ITEM_DETAIL.getPrefix(), Directory.ITEM_THUMBNAIL_ORIGIN.getPrefix());
         try {
@@ -97,5 +101,17 @@ public class ImageHostService implements ProfileUpload, ItemDetailImageUpload, I
             return url.split("amazonaws.com/")[1];
         }
         return url;
+    }
+
+    @Override
+    public List<ItemDetailImage> uploadItemDetailImages(List<MultipartFile> request) throws ImageHostException {
+        List<ItemDetailImage> images = new ArrayList<>();
+
+        for (int i=0; i<request.size(); i++) {
+            ImageInfo imageInfo = uploadItemDetailImage(request.get(i));
+            images.add(ItemDetailImage.create(i, imageInfo.getImageUrl()));
+        }
+
+        return images;
     }
 }

--- a/backend/src/main/java/com/team5/secondhand/global/aws/service/usecase/ItemDetailImageUpload.java
+++ b/backend/src/main/java/com/team5/secondhand/global/aws/service/usecase/ItemDetailImageUpload.java
@@ -1,9 +1,15 @@
 package com.team5.secondhand.global.aws.service.usecase;
 
+import com.team5.secondhand.api.item.domain.ItemDetailImage;
 import com.team5.secondhand.global.aws.dto.response.ImageInfo;
 import com.team5.secondhand.global.aws.exception.ImageHostException;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+import java.util.Map;
+
 public interface ItemDetailImageUpload {
-    ImageInfo uploadItemDetailImage(MultipartFile request) throws ImageHostException;
+    List<ItemDetailImage> uploadItemDetailImages(List<MultipartFile> request) throws ImageHostException;
+
+    ImageInfo uploadItemDetailImage(MultipartFile itemImages) throws ImageHostException;
 }

--- a/backend/src/main/java/com/team5/secondhand/global/aws/service/usecase/ItemThumbnailImageUpload.java
+++ b/backend/src/main/java/com/team5/secondhand/global/aws/service/usecase/ItemThumbnailImageUpload.java
@@ -1,7 +1,8 @@
 package com.team5.secondhand.global.aws.service.usecase;
 
+import com.team5.secondhand.api.item.domain.Item;
 import com.team5.secondhand.global.aws.exception.ImageHostException;
 
 public interface ItemThumbnailImageUpload {
-    String uploadItemThumbnailImage(String imageUrl) throws ImageHostException;
+    String uploadItemThumbnailImage(Item item) throws ImageHostException;
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -10,9 +10,6 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 100MB
-    session:
-      cookie:
-        domain: 3.37.51.148
   jpa:
     properties:
       hibernate:


### PR DESCRIPTION
## 구현사항
- 상품 이미지 등록시 최대 10장의 multipartFile을 업로드할 수 있다.
- session 에 들어가는 도메인을 `dns` 링크로 수정해둠

## 테스트시 주의사항
- 이미지 수정 로직은 아직 구현 방식 변경을 안했음. 테스트 불가

## Refs.
- #173
- #157 
- #141 