### PR TITLE
[#228] FEAT: portal 닫은 후 홈 재렌더링 기능 구현

### DIFF
--- a/front-end/src/pages/Home.tsx
+++ b/front-end/src/pages/Home.tsx
@@ -67,12 +67,26 @@ const Home = () => {
     return filterQuery;
   };
 
+  const initData = () => {
+    setSaleItems([]);
+    setHomePageInfo({
+      page: 0,
+      hasPrevious: false,
+      hasNext: true,
+    });
+  };
+
   const handleCategoryModal = () => {
     setIsCategoryModalOpen((prev) => !prev);
   };
 
+  const [onRefresh, setOnRefresh] = useState(false);
   const handleNewModal = () => {
     setIsNewModalOpen((prev) => !prev);
+    if (isNewModalOpen) {
+      initData();
+      setOnRefresh(true);
+    }
   };
 
   // 필터가 한 번 밖에 안 돼...
@@ -87,6 +101,7 @@ const Home = () => {
 
   const fetchItems = async () => {
     if (!homePageInfo.hasNext) return;
+
     const filterQuery = createFilterQuery();
 
     try {
@@ -129,6 +144,14 @@ const Home = () => {
   useEffect(() => {
     fetchItems();
   }, [filterInfo]);
+
+  useEffect(() => {
+    // TODO: PR merge 후, 상품디테일 창 close시에도 적용하기
+    if (onRefresh) {
+      fetchItems();
+      setOnRefresh(false);
+    }
+  }, [onRefresh]);
 
   useEffect(() => {
     getCategoryInfo();


### PR DESCRIPTION
### 아래 portal이 닫힌 후 상품 리스트 API 통신 및 렌더링 되어야 한다.
- [x] 새로운 상품 등록 후
- [ ] 상품 상세 정보 조회 후 (PR merge 후 예정)
- [ ] 게시글 수정 후 (작업 진행 후 예정)