### PR TITLE
[iOS] 무한스크롤 

### DIFF
--- a/iOS/second-hand/second-hand/Home/Controller/HomeViewController.swift
+++ b/iOS/second-hand/second-hand/Home/Controller/HomeViewController.swift
@@ -32,12 +32,15 @@ final class HomeViewController: NavigationUnderLineViewController, ButtonCustomV
         setNavigationLeftBarButton()
         setRegisterProductButton()
         setObserver()
-        getItemList()
+        setupInfiniteScroll()
         setupDataSource()
         
     }
     
-    private func applyInitialSnapshot() {
+    private func setupInfiniteScroll() {
+            productListCollectionView.delegate = self
+        }
+    
         var snapshot = NSDiffableDataSourceSnapshot<Section, SellingItem>()
         snapshot.appendSections([.main])
         snapshot.appendItems(self.items, toSection: .main)
@@ -168,6 +171,14 @@ final class HomeViewController: NavigationUnderLineViewController, ButtonCustomV
 
 }
 
-extension HomeViewController : UICollectionViewDelegate {
-    
+extension HomeViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        let lastSection = collectionView.numberOfSections - 1
+        let lastItem = collectionView.numberOfItems(inSection: lastSection) - 1
+        
+        if indexPath.section == lastSection && indexPath.item == lastItem {
+            loadNextPage()
+        }
+    }
 }
+

--- a/iOS/second-hand/second-hand/Home/Controller/HomeViewController.swift
+++ b/iOS/second-hand/second-hand/Home/Controller/HomeViewController.swift
@@ -23,7 +23,9 @@ final class HomeViewController: NavigationUnderLineViewController, ButtonCustomV
     private var dataSource: UICollectionViewDiffableDataSource<Section, SellingItem>!
     private var isLogin = false
     private let registerProductButton = UIButton()
-
+    private var currentPage: Int = 0
+    private var isLoadingItems = true
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -33,6 +35,7 @@ final class HomeViewController: NavigationUnderLineViewController, ButtonCustomV
         setRegisterProductButton()
         setObserver()
         setupInfiniteScroll()
+        getItemList(page: currentPage)
         setupDataSource()
         
     }
@@ -41,6 +44,16 @@ final class HomeViewController: NavigationUnderLineViewController, ButtonCustomV
             productListCollectionView.delegate = self
         }
     
+    private func loadNextPage() {
+            if !isLoadingItems {
+                return
+            }
+        self.isLoadingItems  = true
+        currentPage += 1
+        getItemList(page: currentPage)
+        }
+    
+    private func applySnapshot() {
         var snapshot = NSDiffableDataSourceSnapshot<Section, SellingItem>()
         snapshot.appendSections([.main])
         snapshot.appendItems(self.items, toSection: .main)
@@ -145,9 +158,9 @@ final class HomeViewController: NavigationUnderLineViewController, ButtonCustomV
         return result
     }
     
-    private func getItemList() {
+    private func getItemList(page: Int) {
         
-        guard let url = URL(string: Server.shared.itemsListURL(page: 2, regionID: 1)) else {
+        guard let url = URL(string: Server.shared.itemsListURL(page: page, regionID: 1)) else {
             return
         }
         
@@ -158,10 +171,15 @@ final class HomeViewController: NavigationUnderLineViewController, ButtonCustomV
                     return
                 }
                 
+                if itemList.items.count == 0 {
+                    self.isLoadingItems = false
+                    print("마지막 페이지에 대한 처리")
+                }
+                
                 itemList.items.forEach { item in
                     self.items.append(self.convertToHashable(from: item))
                 }
-                self.applyInitialSnapshot()
+                self.applySnapshot()
                 
             case .failure(let error) :
                 print(error.localizedDescription)


### PR DESCRIPTION
무한스크롤 구현 

- 마지막 섹션의 마지막 아이템이 보이면 display되면 다음 페이지 GET 
- 처음 cell이 로드될 땐 문제가 없으나, cell이 reuse될 때 statusLabel이 정상적으로 나오지 않는 문제가 있음. 

-> 해결방법 
1. prepareForReuse 에서 reuse될 때 제약 deactivate 하고 다시 잡기 ( 똑같은 현상 발생 )
2. prepareForReuse 에서 reuse될 때 view 제거하고 다시 만들어서 넣기 ( 똑같은 현상 발생 )
3. layoutSubView를 이용
4. 3번도 안된다면 스택뷰로 묶어서 처리 