### PR TITLE
iOS - #285 채팅방 열기 구현 

### DIFF
--- a/iOS/.gitignore
+++ b/iOS/.gitignore
@@ -88,3 +88,6 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+# Ignore Secrets.plist
+Secrets/

--- a/iOS/second-hand/Podfile
+++ b/iOS/second-hand/Podfile
@@ -6,6 +6,7 @@ target 'second-hand' do
   use_frameworks!
 
   # Pods for second-hand
-  pod 'SwiftLint' 
+  pod 'SwiftLint'
+  pod 'StompClientLib' 
 
 end

--- a/iOS/second-hand/Podfile.lock
+++ b/iOS/second-hand/Podfile.lock
@@ -1,16 +1,24 @@
 PODS:
+  - SocketRocket (0.7.0)
+  - StompClientLib (1.4.1):
+    - SocketRocket
   - SwiftLint (0.51.0)
 
 DEPENDENCIES:
+  - StompClientLib
   - SwiftLint
 
 SPEC REPOS:
   trunk:
+    - SocketRocket
+    - StompClientLib
     - SwiftLint
 
 SPEC CHECKSUMS:
+  SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
+  StompClientLib: ac40390e9660c574675f1c933bec81c8e2811a4f
   SwiftLint: 1b7561918a19e23bfed960e40759086e70f4dba5
 
-PODFILE CHECKSUM: 000a1fecb910b1bf0367a33e65bdc4c72060f52b
+PODFILE CHECKSUM: eaea9746c1c6833974ee539581c3b85a6b78264d
 
 COCOAPODS: 1.12.1

--- a/iOS/second-hand/second-hand.xcodeproj/project.pbxproj
+++ b/iOS/second-hand/second-hand.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		E4375C172A666843003F6F5B /* SocketManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4375C162A666843003F6F5B /* SocketManager.swift */; };
 		E4375C192A67D82D003F6F5B /* ChattingRoomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4375C182A67D82D003F6F5B /* ChattingRoomViewController.swift */; };
 		E4375C1C2A67DBE4003F6F5B /* ButtonActionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4375C1B2A67DBE4003F6F5B /* ButtonActionDelegate.swift */; };
+		E4375C232A6A7D31003F6F5B /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = E4375C222A6A7D31003F6F5B /* Secrets.plist */; };
 		E448042C2A5D56C300FDADE4 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E448042B2A5D56C300FDADE4 /* Utils.swift */; };
 		E448042F2A5EA25600FDADE4 /* ItemDetailModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E448042E2A5EA25600FDADE4 /* ItemDetailModel.swift */; };
 		E467380D2A440D0E006A46D1 /* UserInfoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E467380C2A440D0E006A46D1 /* UserInfoManager.swift */; };
@@ -104,6 +105,7 @@
 		E4375C162A666843003F6F5B /* SocketManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketManager.swift; sourceTree = "<group>"; };
 		E4375C182A67D82D003F6F5B /* ChattingRoomViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChattingRoomViewController.swift; sourceTree = "<group>"; };
 		E4375C1B2A67DBE4003F6F5B /* ButtonActionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonActionDelegate.swift; sourceTree = "<group>"; };
+		E4375C222A6A7D31003F6F5B /* Secrets.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Secrets.plist; sourceTree = "<group>"; };
 		E448042B2A5D56C300FDADE4 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		E448042E2A5EA25600FDADE4 /* ItemDetailModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailModel.swift; sourceTree = "<group>"; };
 		E467380C2A440D0E006A46D1 /* UserInfoManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoManager.swift; sourceTree = "<group>"; };
@@ -367,6 +369,7 @@
 		DBB04D1E2A2DA5BF001233CC = {
 			isa = PBXGroup;
 			children = (
+				E4375C212A6A7D21003F6F5B /* Secrets */,
 				DBB04D292A2DA5BF001233CC /* second-hand */,
 				DBB04D282A2DA5BF001233CC /* Products */,
 				94BA97CE86293EDB3FC68F03 /* Pods */,
@@ -407,6 +410,14 @@
 				E4375C182A67D82D003F6F5B /* ChattingRoomViewController.swift */,
 			);
 			path = subScene;
+			sourceTree = "<group>";
+		};
+		E4375C212A6A7D21003F6F5B /* Secrets */ = {
+			isa = PBXGroup;
+			children = (
+				E4375C222A6A7D31003F6F5B /* Secrets.plist */,
+			);
+			path = Secrets;
 			sourceTree = "<group>";
 		};
 		E448042D2A5EA21000FDADE4 /* Model */ = {
@@ -695,6 +706,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DBB04D372A2DA5C0001233CC /* LaunchScreen.storyboard in Resources */,
+				E4375C232A6A7D31003F6F5B /* Secrets.plist in Resources */,
 				DBB04D342A2DA5C0001233CC /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS/second-hand/second-hand.xcodeproj/project.pbxproj
+++ b/iOS/second-hand/second-hand.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		E4375C192A67D82D003F6F5B /* ChattingRoomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4375C182A67D82D003F6F5B /* ChattingRoomViewController.swift */; };
 		E4375C1C2A67DBE4003F6F5B /* ButtonActionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4375C1B2A67DBE4003F6F5B /* ButtonActionDelegate.swift */; };
 		E4375C232A6A7D31003F6F5B /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = E4375C222A6A7D31003F6F5B /* Secrets.plist */; };
+		E4375C252A6D9004003F6F5B /* PrivateChatroomModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4375C242A6D9004003F6F5B /* PrivateChatroomModel.swift */; };
 		E448042C2A5D56C300FDADE4 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E448042B2A5D56C300FDADE4 /* Utils.swift */; };
 		E448042F2A5EA25600FDADE4 /* ItemDetailModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E448042E2A5EA25600FDADE4 /* ItemDetailModel.swift */; };
 		E467380D2A440D0E006A46D1 /* UserInfoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E467380C2A440D0E006A46D1 /* UserInfoManager.swift */; };
@@ -106,6 +107,7 @@
 		E4375C182A67D82D003F6F5B /* ChattingRoomViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChattingRoomViewController.swift; sourceTree = "<group>"; };
 		E4375C1B2A67DBE4003F6F5B /* ButtonActionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonActionDelegate.swift; sourceTree = "<group>"; };
 		E4375C222A6A7D31003F6F5B /* Secrets.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Secrets.plist; sourceTree = "<group>"; };
+		E4375C242A6D9004003F6F5B /* PrivateChatroomModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateChatroomModel.swift; sourceTree = "<group>"; };
 		E448042B2A5D56C300FDADE4 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		E448042E2A5EA25600FDADE4 /* ItemDetailModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailModel.swift; sourceTree = "<group>"; };
 		E467380C2A440D0E006A46D1 /* UserInfoManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoManager.swift; sourceTree = "<group>"; };
@@ -553,6 +555,7 @@
 		E49EB8642A36F037001F2D56 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				E4375C242A6D9004003F6F5B /* PrivateChatroomModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -802,6 +805,7 @@
 				E46EFD0C2A64511300FFC3B8 /* ItemDetailBottomSectionView.swift in Sources */,
 				E49EB8542A30690F001F2D56 /* HomeRightBarButton.swift in Sources */,
 				DB55CB092A43E58800578ED5 /* UIView+Extension.swift in Sources */,
+				E4375C252A6D9004003F6F5B /* PrivateChatroomModel.swift in Sources */,
 				E49EB83C2A2DD3AF001F2D56 /* WishListViewController.swift in Sources */,
 				DBAF838A2A32B7CA00194A02 /* NavigationUnderLineViewController.swift in Sources */,
 				E49EB8362A2DC207001F2D56 /* TabBarItem.swift in Sources */,

--- a/iOS/second-hand/second-hand.xcodeproj/project.pbxproj
+++ b/iOS/second-hand/second-hand.xcodeproj/project.pbxproj
@@ -35,6 +35,9 @@
 		DBEA32812A4101B400C04E0A /* HomeProductCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBEA32802A4101B400C04E0A /* HomeProductCollectionViewCell.swift */; };
 		E41076C22A49B5EC00F5204E /* IdInputSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41076C12A49B5EC00F5204E /* IdInputSection.swift */; };
 		E41076C42A4AF67A00F5204E /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41076C32A4AF67A00F5204E /* ImageCacheManager.swift */; };
+		E4375C172A666843003F6F5B /* SocketManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4375C162A666843003F6F5B /* SocketManager.swift */; };
+		E4375C192A67D82D003F6F5B /* ChattingRoomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4375C182A67D82D003F6F5B /* ChattingRoomViewController.swift */; };
+		E4375C1C2A67DBE4003F6F5B /* ButtonActionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4375C1B2A67DBE4003F6F5B /* ButtonActionDelegate.swift */; };
 		E448042C2A5D56C300FDADE4 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E448042B2A5D56C300FDADE4 /* Utils.swift */; };
 		E448042F2A5EA25600FDADE4 /* ItemDetailModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E448042E2A5EA25600FDADE4 /* ItemDetailModel.swift */; };
 		E467380D2A440D0E006A46D1 /* UserInfoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E467380C2A440D0E006A46D1 /* UserInfoManager.swift */; };
@@ -98,6 +101,9 @@
 		DBEA32802A4101B400C04E0A /* HomeProductCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeProductCollectionViewCell.swift; sourceTree = "<group>"; };
 		E41076C12A49B5EC00F5204E /* IdInputSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdInputSection.swift; sourceTree = "<group>"; };
 		E41076C32A4AF67A00F5204E /* ImageCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
+		E4375C162A666843003F6F5B /* SocketManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketManager.swift; sourceTree = "<group>"; };
+		E4375C182A67D82D003F6F5B /* ChattingRoomViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChattingRoomViewController.swift; sourceTree = "<group>"; };
+		E4375C1B2A67DBE4003F6F5B /* ButtonActionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonActionDelegate.swift; sourceTree = "<group>"; };
 		E448042B2A5D56C300FDADE4 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		E448042E2A5EA25600FDADE4 /* ItemDetailModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailModel.swift; sourceTree = "<group>"; };
 		E467380C2A440D0E006A46D1 /* UserInfoManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoManager.swift; sourceTree = "<group>"; };
@@ -395,6 +401,14 @@
 			path = "second-hand";
 			sourceTree = "<group>";
 		};
+		E4375C1A2A67D835003F6F5B /* subScene */ = {
+			isa = PBXGroup;
+			children = (
+				E4375C182A67D82D003F6F5B /* ChattingRoomViewController.swift */,
+			);
+			path = subScene;
+			sourceTree = "<group>";
+		};
 		E448042D2A5EA21000FDADE4 /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -409,6 +423,7 @@
 				DBB04D2C2A2DA5BF001233CC /* SceneDelegate.swift */,
 				DBB04D2A2A2DA5BF001233CC /* AppDelegate.swift */,
 				E448042B2A5D56C300FDADE4 /* Utils.swift */,
+				E4375C1B2A67DBE4003F6F5B /* ButtonActionDelegate.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -447,6 +462,7 @@
 		E49EB8472A3049EB001F2D56 /* Chatting */ = {
 			isa = PBXGroup;
 			children = (
+				E4375C1A2A67D835003F6F5B /* subScene */,
 				E49EB8652A36F03F001F2D56 /* Controller */,
 				E49EB8642A36F037001F2D56 /* Model */,
 				E49EB8632A36F02B001F2D56 /* View */,
@@ -582,6 +598,7 @@
 				E467380E2A453FBF006A46D1 /* Server.swift */,
 				E46738102A482DF1006A46D1 /* Updatable.swift */,
 				E41076C32A4AF67A00F5204E /* ImageCacheManager.swift */,
+				E4375C162A666843003F6F5B /* SocketManager.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -628,6 +645,7 @@
 				DBB04D232A2DA5BF001233CC /* Sources */,
 				DBB04D242A2DA5BF001233CC /* Frameworks */,
 				DBB04D252A2DA5BF001233CC /* Resources */,
+				A0D4DFD7E4D61947269C9B44 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -706,6 +724,23 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		A0D4DFD7E4D61947269C9B44 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-second-hand/Pods-second-hand-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-second-hand/Pods-second-hand-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-second-hand/Pods-second-hand-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -724,6 +759,7 @@
 				DBE3C03D2A30791F00E6EF35 /* CategoryScrollView.swift in Sources */,
 				E49EB83A2A2DD353001F2D56 /* SaleLogViewController.swift in Sources */,
 				E46EFD062A61AFDF00FFC3B8 /* ItemDetailTextSectionView.swift in Sources */,
+				E4375C1C2A67DBE4003F6F5B /* ButtonActionDelegate.swift in Sources */,
 				E41076C42A4AF67A00F5204E /* ImageCacheManager.swift in Sources */,
 				E49EB8672A36F054001F2D56 /* ChattingViewController.swift in Sources */,
 				E4C9514E2A3AFC0D0094AD66 /* HTTPErrors.swift in Sources */,
@@ -737,13 +773,14 @@
 				E448042F2A5EA25600FDADE4 /* ItemDetailModel.swift in Sources */,
 				E467380F2A453FBF006A46D1 /* Server.swift in Sources */,
 				E4987E452A4D9F7600337543 /* Int,String+Extension.swift in Sources */,
+				E4375C172A666843003F6F5B /* SocketManager.swift in Sources */,
 				DB51315F2A3EB18800FBFA49 /* SetLocationViewController.swift in Sources */,
+				E4375C192A67D82D003F6F5B /* ChattingRoomViewController.swift in Sources */,
 				DB55CB112A4407CB00578ED5 /* ProductPictureCount.swift in Sources */,
 				E49EB8562A306E68001F2D56 /* ButtonCustomView.swift in Sources */,
 				E46EFD082A62F1F400FFC3B8 /* StatusButton.swift in Sources */,
 				E448042C2A5D56C300FDADE4 /* Utils.swift in Sources */,
 				E4C9514C2A3AFBDC0094AD66 /* HTTPMethod.swift in Sources */,
-				DB1636C82A42E65B009884E4 /* RegisterNewProductViewController.swift in Sources */,
 				E46EFD042A61A73400FFC3B8 /* SellerInfoView.swift in Sources */,
 				E49EB8342A2DB498001F2D56 /* SecondHandTabBarController.swift in Sources */,
 				DB51AD982A5A97E200EB939D /* RegisterNewProductViewController.swift in Sources */,

--- a/iOS/second-hand/second-hand/Application/ButtonActionDelegate.swift
+++ b/iOS/second-hand/second-hand/Application/ButtonActionDelegate.swift
@@ -1,0 +1,12 @@
+//
+//  ButtonActionDelegate.swift
+//  second-hand
+//
+//  Created by SONG on 2023/07/19.
+//
+
+import Foundation
+
+@objc protocol ButtonActionDelegate {
+    @objc optional func requestOpenChattingRoom()
+}

--- a/iOS/second-hand/second-hand/Application/ButtonActionDelegate.swift
+++ b/iOS/second-hand/second-hand/Application/ButtonActionDelegate.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 @objc protocol ButtonActionDelegate {
-    @objc optional func requestOpenChattingRoom()
+    @objc optional func requestForChattingRoom()
 }

--- a/iOS/second-hand/second-hand/Chatting/Model/PrivateChatroomModel.swift
+++ b/iOS/second-hand/second-hand/Chatting/Model/PrivateChatroomModel.swift
@@ -1,0 +1,20 @@
+//
+//  PrivateChatroomData.swift
+//  second-hand
+//
+//  Created by SONG on 2023/07/24.
+//
+
+import Foundation
+
+class PrivateChatroomModel: Updatable {
+    var info : ChatroomData? = nil
+    
+    func updateData<T>(from fetchedData: T) where T : Decodable, T : Encodable {
+        guard let data = fetchedData as? ChatroomData else{
+            print("캐스팅실패")
+            return
+        }
+        self.info = data
+    }
+}

--- a/iOS/second-hand/second-hand/Chatting/subScene/ChattingRoomViewController.swift
+++ b/iOS/second-hand/second-hand/Chatting/subScene/ChattingRoomViewController.swift
@@ -1,0 +1,17 @@
+//
+//  ChattingRoomViewController.swift
+//  second-hand
+//
+//  Created by SONG on 2023/07/19.
+//
+
+import UIKit
+
+class ChattingRoomViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .red
+    }
+
+}

--- a/iOS/second-hand/second-hand/Chatting/subScene/ChattingRoomViewController.swift
+++ b/iOS/second-hand/second-hand/Chatting/subScene/ChattingRoomViewController.swift
@@ -8,10 +8,134 @@
 import UIKit
 
 class ChattingRoomViewController: UIViewController {
-
+    private var backButton: UIButton? = nil
+    private var menuButton: UIButton? = nil
+    private var chatroomTitle: UILabel? = nil
+    var privateChatroomModel = PrivateChatroomModel()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = .red
+        commonInit()
     }
 
+    private func commonInit() {
+        self.view.backgroundColor = .systemBackground
+        generateBackButton()
+        generateMenuButton()
+        setConstraintsBackButton()
+        setConstraintsMenuButton()
+        didUpdateModel()
+    }
+    
+    private func didUpdateModel() {
+        setChatroomTitle()
+    }
+    
+    // MARK: NavigationBar (Buttons , title)
+    private func setChatroomTitle() {
+        self.chatroomTitle = UILabel(frame: .zero)
+        self.chatroomTitle?.text = privateChatroomModel.info?.opponentId
+
+        self.chatroomTitle?.font = .systemFont(ofSize: 17.0)
+        self.chatroomTitle?.textAlignment = .center
+        setConstraintsChatroomTitle()
+    }
+    
+    private func bringButtonsToFront() {
+        guard let backButton = self.backButton else {
+            return
+        }
+        
+        guard let menuButton = self.menuButton else {
+            return
+        }
+        
+        self.view.bringSubviewToFront(backButton)
+        self.view.bringSubviewToFront(menuButton)
+    }
+    
+    private func generateBackButton() {
+        let button = UIButton(type: .system)
+        button.setImage(UIImage(systemName: "chevron.backward"), for: .normal)
+        button.setTitle("뒤로", for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 17.0)
+        button.tintColor = .black
+        button.addTarget(self, action: #selector(backButtonTouched), for: .touchUpInside)
+        self.backButton = button
+    }
+    
+    private func generateMenuButton() {
+        let button = UIButton(type: .system)
+        button.setImage(UIImage(systemName: "ellipsis"), for: .normal)
+        button.tintColor = .black
+        button.addTarget(self, action:#selector(menuButtonTouched), for: .touchUpInside)
+        self.menuButton = button
+        
+    }
+    
+    private func setConstraintsBackButton() {
+        guard let backButton = self.backButton else {
+            return
+        }
+        
+        self.view.addSubview(backButton)
+        
+        backButton.translatesAutoresizingMaskIntoConstraints = false
+        backButton.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 10).isActive = true
+        backButton.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor, constant: 8).isActive = true
+    }
+    
+    private func setConstraintsMenuButton() {
+        guard let menubutton = self.menuButton else {
+            return
+        }
+        
+        self.view.addSubview(menubutton)
+        
+        menubutton.translatesAutoresizingMaskIntoConstraints = false
+        
+        menubutton.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -10).isActive = true
+        menubutton.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor, constant: 8).isActive = true
+    }
+    
+    private func setConstraintsChatroomTitle() {
+        guard let chatroomTitle = self.chatroomTitle else {
+            return
+        }
+        
+        guard let backButton = self.backButton else {
+            return
+        }
+        
+        guard let text = chatroomTitle.text else {
+            return
+        }
+        
+        let width: CGFloat = round(CGFloat(text.count) * 15.0)
+        
+        self.view.addSubview(chatroomTitle)
+        
+        chatroomTitle.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate(
+            [
+                chatroomTitle.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+                chatroomTitle.centerYAnchor.constraint(equalTo: backButton.centerYAnchor),
+                chatroomTitle.widthAnchor.constraint(equalToConstant: width),
+                chatroomTitle.heightAnchor.constraint(equalTo: backButton.heightAnchor)
+            ]
+        )
+    }
+    
+    private func hideNavigationBar() {
+        navigationController?.setNavigationBarHidden(true, animated: true)
+    }
+    
+    @objc private func backButtonTouched() {
+        navigationController?.popViewController(animated: true)
+    }
+    
+    @objc private func menuButtonTouched() {
+        
+    }
 }

--- a/iOS/second-hand/second-hand/Home/ButtonCustomView.swift
+++ b/iOS/second-hand/second-hand/Home/ButtonCustomView.swift
@@ -12,7 +12,6 @@ protocol ButtonCustomViewDelegate {
 }
 
 final class ButtonCustomView: UIButton {
-    var delegate: ButtonCustomViewDelegate?
     
     private var label = UILabel(frame: .zero)
     private var sideImage = UIImageView(frame: .zero)
@@ -62,7 +61,7 @@ final class ButtonCustomView: UIButton {
         [
 
             UIAction(title: "동네를 설정하세요", handler: { [weak self] _ in
-                self?.delegate?.tappedSetLocation()
+                
             })
 
         ]

--- a/iOS/second-hand/second-hand/Home/Controller/HomeViewController.swift
+++ b/iOS/second-hand/second-hand/Home/Controller/HomeViewController.swift
@@ -167,10 +167,10 @@ final class HomeViewController: NavigationUnderLineViewController{
         guard let url = URL(string: Server.shared.itemsListURL(page: page, regionID: 2729060200)) else {
             return
         }
-        NetworkManager.sendGET(decodeType: ItemList.self, what: nil, fromURL: url) { (result: Result<[ItemList], Error>) in
+        NetworkManager.sendGET(decodeType: ItemListSuccess.self, what: nil, fromURL: url) { (result: Result<[ItemListSuccess], Error>) in
             switch result {
-            case .success(let data) :
-                guard let itemList = data.last else {
+            case .success(let response) :
+                guard let itemList = response.last?.data else {
                     return
                 }
                 

--- a/iOS/second-hand/second-hand/Home/Controller/HomeViewController.swift
+++ b/iOS/second-hand/second-hand/Home/Controller/HomeViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class HomeViewController: NavigationUnderLineViewController, ButtonCustomViewDelegate {
+final class HomeViewController: NavigationUnderLineViewController{
     
     enum Section: CaseIterable {
         case main
@@ -110,7 +110,6 @@ final class HomeViewController: NavigationUnderLineViewController, ButtonCustomV
     private func setNavigationLeftBarButton() {
         let leftBarButton = HomeLeftBarButton()
         let buttonCustomView = leftBarButton.customView as? ButtonCustomView
-        buttonCustomView?.delegate = self
         navigationController?.navigationBar.topItem?.leftBarButtonItem = leftBarButton
     }
 
@@ -164,11 +163,10 @@ final class HomeViewController: NavigationUnderLineViewController, ButtonCustomV
     }
     
     private func getItemList(page: Int) {
-        
-        guard let url = URL(string: Server.shared.itemsListURL(page: page, regionID: 1)) else {
+        // TODO: 리전 하드코딩 없애기
+        guard let url = URL(string: Server.shared.itemsListURL(page: page, regionID: 2729060200)) else {
             return
         }
-        
         NetworkManager.sendGET(decodeType: ItemList.self, what: nil, fromURL: url) { (result: Result<[ItemList], Error>) in
             switch result {
             case .success(let data) :
@@ -206,7 +204,7 @@ extension HomeViewController: UICollectionViewDelegate {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         
-        let id = extractItemIdFromTouchedCell(indexPath: indexPath)
+        let id = items[indexPath.item].id
         
         let url = Server.shared.itemDetailURL(itemId: id)
         let itemDetailViewController = ItemDetailViewController()
@@ -218,12 +216,6 @@ extension HomeViewController: UICollectionViewDelegate {
     
     private func hideTabBar() {
         tabBarController?.tabBar.isHidden = true
-    }
-    
-    //TODO: 콜렉션뷰 아래 섹션으로 가면 값이 이상해진다. 추후 확인하도록.
-    private func extractItemIdFromTouchedCell(indexPath: IndexPath) -> Int{
-        let itemId = items[IndexPath(item: .zero, section: .zero).item].id - indexPath.item
-        return itemId
     }
 }
 

--- a/iOS/second-hand/second-hand/Home/subScene/ItemDetail/Controller/ItemDetailViewController.swift
+++ b/iOS/second-hand/second-hand/Home/subScene/ItemDetail/Controller/ItemDetailViewController.swift
@@ -16,12 +16,13 @@ class ItemDetailViewController: UIViewController {
     private var textSectionView = ItemDetailTextSectionView(frame: .zero)
     private var bottomSectionView = ItemDetailBottomSectionView(frame: .zero)
     
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setItemDetailModel()
         initializeScene()
     }
-
+    
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         bringButtonsToFront()
@@ -246,6 +247,7 @@ class ItemDetailViewController: UIViewController {
         bottomSectionView.setLikeButton(isLike: isLike)
         bottomSectionView.setPriceLabel(price: price)
         bottomSectionView.setChattingRoomButton(isMine: isMine)
+        bottomSectionView.delegate = self
     }
     
     private func setBottomSectionViewConstraints() {
@@ -263,3 +265,26 @@ class ItemDetailViewController: UIViewController {
         )
     }
 }
+
+//MARK: DELEGATE
+
+extension ItemDetailViewController : ButtonActionDelegate {
+    func requestOpenChattingRoom() {
+        if !UserInfoManager.shared.isLogOn {
+            let alertController = UIAlertController(
+                title: "로그인이 필요합니다",
+                message: "당장하라",
+                preferredStyle: .alert
+            )
+            alertController.addAction(
+                UIAlertAction(title: "확인", style: .default, handler: nil)
+            )
+            present(alertController, animated: true, completion: nil)
+        } else {
+            
+        }
+    }
+    
+    
+}
+

--- a/iOS/second-hand/second-hand/Home/subScene/ItemDetail/Controller/ItemDetailViewController.swift
+++ b/iOS/second-hand/second-hand/Home/subScene/ItemDetail/Controller/ItemDetailViewController.swift
@@ -294,14 +294,14 @@ extension ItemDetailViewController : ButtonActionDelegate {
             
             NetworkManager.sendGET(decodeType: ChatroomSuccess.self, what: nil, fromURL: url) { (result: Result<[ChatroomSuccess], Error>) in
                 switch result {
-                case .success(let data) :
-                    guard let response = data.last else {
+                case .success(let reposonse) :
+                    guard let response = reposonse.last else {
                         return
                     }
                     
                     if let chatRoomId = response.data.chatroomId {
                         print("채팅방입장")
-                        self.enterChattingRoom(chatroomId: chatRoomId)
+                        self.changeToChatroomViewController(fetchedData: response)
                         
                     } else {
                         print("채팅방생성")
@@ -322,11 +322,12 @@ extension ItemDetailViewController : ButtonActionDelegate {
         
         NetworkManager.sendGET(decodeType: ChatroomSuccess.self, what: nil, fromURL: url) { (result: Result<[ChatroomSuccess], Error>) in
             switch result {
-            case .success(let data) :
-                guard let data = data.last else {
+            case .success(let response) :
+                guard let response = response.last else {
                     return
                 }
-                print(data)
+
+                self.changeToChatroomViewController(fetchedData: response)
                 
             case .failure(let error) :
                 print(error.localizedDescription)
@@ -339,17 +340,25 @@ extension ItemDetailViewController : ButtonActionDelegate {
         guard let url = URL(string: Server.shared.requestToCreateChattingRoom()) else {
             return
         }
-        
+
         NetworkManager().sendPOST(decodeType: CommonAPIResponse.self, what: body, header: nil, fromURL: url ){ (result: Result<CommonAPIResponse, Error>) in
             switch result {
-            case .success(let data) :
-                print(data)
+            case .success(let response) :
+                self.enterChattingRoom(chatroomId: response.data)
                 
             case .failure(let error) :
                 print(error.localizedDescription)
             }
         }
     }
-}
+    
+    private func changeToChatroomViewController(fetchedData: ChatroomSuccess) {
+        
+        let privateChatroom = ChattingRoomViewController()
 
+        privateChatroom.privateChatroomModel.updateData(from: fetchedData.data)
+        
+        self.navigationController?.pushViewController(privateChatroom, animated: true)
+    }
+}
 

--- a/iOS/second-hand/second-hand/Home/subScene/ItemDetail/VIew/ContentOfPost.swift
+++ b/iOS/second-hand/second-hand/Home/subScene/ItemDetail/VIew/ContentOfPost.swift
@@ -34,9 +34,9 @@ class ContentOfPost: UIView {
         let titleHeight = titleLabel.intrinsicContentSize.height
         let categoryHeight = categotyAndCreateAtLabel.intrinsicContentSize.height
         let descriptionHeight = descriptionView.intrinsicContentSize.height
-        let countHegith = countsLabel.intrinsicContentSize.height
+        let countHeight = countsLabel.intrinsicContentSize.height
         
-        let totalHeight = titleHeight + categoryHeight + descriptionHeight + countHegith + 30 
+        let totalHeight = titleHeight + categoryHeight + descriptionHeight + countHeight + 30 
 
         return CGSize(width: contentWidth, height: totalHeight)
     }

--- a/iOS/second-hand/second-hand/Home/subScene/ItemDetail/VIew/ItemDetailBottomSectionView.swift
+++ b/iOS/second-hand/second-hand/Home/subScene/ItemDetail/VIew/ItemDetailBottomSectionView.swift
@@ -11,6 +11,8 @@ class ItemDetailBottomSectionView: UIView {
     private var likeButton : UIButton? = nil
     private var priceLabel : UILabel? = nil
     private var chattingRoomButton : UIButton? = nil
+    var delegate: ButtonActionDelegate?
+    
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -173,6 +175,6 @@ class ItemDetailBottomSectionView: UIView {
     }
     
     @objc private func chattingRoomButtonTouched() {
-        print("채팅 버튼 터치시 구현")
+        delegate?.requestOpenChattingRoom?()
     }
 }

--- a/iOS/second-hand/second-hand/Home/subScene/ItemDetail/VIew/ItemDetailBottomSectionView.swift
+++ b/iOS/second-hand/second-hand/Home/subScene/ItemDetail/VIew/ItemDetailBottomSectionView.swift
@@ -175,6 +175,6 @@ class ItemDetailBottomSectionView: UIView {
     }
     
     @objc private func chattingRoomButtonTouched() {
-        delegate?.requestOpenChattingRoom?()
+        delegate?.requestForChattingRoom?()
     }
 }

--- a/iOS/second-hand/second-hand/Home/subScene/ItemDetail/VIew/ItemDetailTextSectionView.swift
+++ b/iOS/second-hand/second-hand/Home/subScene/ItemDetail/VIew/ItemDetailTextSectionView.swift
@@ -122,7 +122,7 @@ class ItemDetailTextSectionView: UIScrollView {
                 [
                     contentOfPost.topAnchor.constraint(equalTo: statusButton.bottomAnchor, constant: 10),
                     contentOfPost.widthAnchor.constraint(equalTo: self.widthAnchor, constant: -30.0),
-                    contentOfPost.heightAnchor.constraint(equalToConstant: contentOfPost.intrinsicContentSize.height),
+                    contentOfPost.heightAnchor.constraint(equalToConstant: self.contentSize.height),
                     contentOfPost.centerXAnchor.constraint(equalTo: self.centerXAnchor)
                 ]
             )

--- a/iOS/second-hand/second-hand/MyAccount/SubScene/GithubWeb/Controller/GithubWebViewController.swift
+++ b/iOS/second-hand/second-hand/MyAccount/SubScene/GithubWeb/Controller/GithubWebViewController.swift
@@ -98,7 +98,7 @@ final class GithubWebViewController: UIViewController {
             return
         }
         
-        NetworkManager.sendOAuthPOST(data: jsonCreater.createJSON(user: requestDataToJoin, region: region),header: cookie, fromURL: path) { (result: Result<Codable, Error>) in
+        NetworkManager.sendOAuthPOST(data: jsonCreater.createGithubLoginRequestBody(user: requestDataToJoin, region: region),header: cookie, fromURL: path) { (result: Result<Codable, Error>) in
             switch result {
             case .success(_) :
                 print("가입성공")

--- a/iOS/second-hand/second-hand/Network/CodableTemplate.swift
+++ b/iOS/second-hand/second-hand/Network/CodableTemplate.swift
@@ -113,3 +113,31 @@ struct Seller: Codable {
 struct ItemDetailImage: Codable {
     let url: String
 }
+
+struct CommonAPIResponse: Codable {
+    let message: String
+    let data: String
+}
+
+//MARK: About Chatting
+
+struct ItemOfChatroom: Codable {
+    let itemId: Int
+    let title: String
+    let price: Int
+    let thumbnailImgUrl: String
+    let status: Int
+    let isDelete: Bool
+}
+
+struct ChatroomData: Codable {
+    let chatroomId: String?
+    let opponentId: String
+    let isOpponentIn: Bool
+    let item: ItemOfChatroom
+}
+
+struct ChatroomSuccess: Codable {
+    let message: String
+    let data: ChatroomData
+}

--- a/iOS/second-hand/second-hand/Network/CodableTemplate.swift
+++ b/iOS/second-hand/second-hand/Network/CodableTemplate.swift
@@ -58,6 +58,11 @@ struct ResponseHeader: Codable {
 
 
 //--------------------------------해당하는 지역의 상품을 볼 수 있다.--------------------------------
+struct ItemListSuccess: Codable {
+    let message : String
+    let data : ItemList
+}
+
 struct ItemList: Codable {
     let number: Int
     let hasPrevious, hasNext: Bool

--- a/iOS/second-hand/second-hand/Network/JSONCreater.swift
+++ b/iOS/second-hand/second-hand/Network/JSONCreater.swift
@@ -12,7 +12,7 @@ class JSONCreater {
     static let headerValueContentType = "application/json"
     static let headerKeyAuthorization = "Authorization"
     
-    func createJSON(user: GitUserNeedsJoin, region: Region) -> Data? {
+    func createGithubLoginRequestBody(user: GitUserNeedsJoin, region: Region) -> Data? {
         
         let userData = UserNeedsJoinRegisterRequest(memberId: user.login, profileImgUrl: user.avatar_url, regions: [region])
 

--- a/iOS/second-hand/second-hand/Network/JSONCreater.swift
+++ b/iOS/second-hand/second-hand/Network/JSONCreater.swift
@@ -15,11 +15,23 @@ class JSONCreater {
     func createGithubLoginRequestBody(user: GitUserNeedsJoin, region: Region) -> Data? {
         
         let userData = UserNeedsJoinRegisterRequest(memberId: user.login, profileImgUrl: user.avatar_url, regions: [region])
-
+        
         let jsonEncoder = JSONEncoder()
         do {
             let jsonData = try jsonEncoder.encode(userData)
             
+            return jsonData
+        } catch {
+            print("JSON encoding error: \(error)")
+            return nil
+        }
+    }
+    
+    func createOpenChatroomRequestBody(itemId:Int) -> Data? {
+        let requestBody: [String: Int] = ["itemId": itemId]
+        
+        do {
+            let jsonData = try JSONEncoder().encode(requestBody)
             return jsonData
         } catch {
             print("JSON encoding error: \(error)")

--- a/iOS/second-hand/second-hand/Network/Server.swift
+++ b/iOS/second-hand/second-hand/Network/Server.swift
@@ -19,6 +19,7 @@ struct Server {
         case gitLogin = "/git/login"
         case login = "/login"
         case items = "/items"
+        case chats = "/chats"
     }
 
     func url(for path: Path) -> String {
@@ -43,7 +44,15 @@ struct Server {
     func itemDetailURL(itemId: Int) -> String {
         return Server.baseURL + Path.items.rawValue + "/" + String(itemId)
     }
-
+    
+    func requestIsExistChattingRoom(itemId: Int) -> String {
+        return Server.baseURL + Path.chats.rawValue + Path.items.rawValue + "/" + String(itemId)
+    }
+    
+    func requestToCreateChattingRoom() -> String {
+        return Server.baseURL + Path.chats.rawValue
+    }
+    
     enum Query: String {
         case code = "code="
         case page = "page="

--- a/iOS/second-hand/second-hand/Network/Server.swift
+++ b/iOS/second-hand/second-hand/Network/Server.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct Server {
     static let shared = Server()
-    static let baseURL = "http://3.37.51.148:8080"
+    static let baseURL = "http://3.37.51.148:81"
     static let oAuthURL = "https://github.com/login/oauth/authorize"
     static let clientID = "5c4b10099c0ae232e5a1"
     static let redirectURL = "http://localhost:5173/login/oauth2/code/github"

--- a/iOS/second-hand/second-hand/Network/SocketManager.swift
+++ b/iOS/second-hand/second-hand/Network/SocketManager.swift
@@ -1,0 +1,57 @@
+//
+//  StompClient.swift
+//  second-hand
+//
+//  Created by SONG on 2023/07/18.
+//
+
+import Foundation
+import StompClientLib
+
+class SocketManager {
+    var socketClient: StompClientLib
+    
+    init() {
+        socketClient = StompClientLib()
+    }
+    
+    func connect() {
+        let socketURL = NSURL(string: "YOUR_SOCKET_URL")!
+        socketClient.openSocketWithURLRequest(request: NSURLRequest(url: socketURL as URL), delegate: self)
+    }
+    
+    func disconnect() {
+        socketClient.disconnect()
+    }
+    
+}
+
+extension SocketManager : StompClientLibDelegate {
+    func stompClientDidConnect(client: StompClientLib!) {
+        print("Socket connected")
+        socketClient.subscribe(destination: "/your/destination/topic")
+    }
+    
+    func stompClientDidDisconnect(client: StompClientLib!) {
+        print("Socket disconnected")
+    }
+    
+    func stompClient(client: StompClientLib!, didReceiveMessageWithJSONBody jsonBody: AnyObject?, akaStringBody stringBody: String?, withHeader header: [String: String]?, withDestination destination: String) {
+        if let messageBody = jsonBody {
+            print("Received JSON message: \(messageBody)")
+        }
+    }
+    
+    func serverDidSendReceipt(client: StompClientLib!, withReceiptId receiptId: String) {
+        print("Server sent receipt with ID: \(receiptId)")
+    }
+    
+    func serverDidSendError(client: StompClientLib!, withErrorMessage description: String, detailedErrorMessage message: String?) {
+        print("Server sent error: \(description)")
+    }
+    
+    func serverDidSendPing() {
+        print("Server sent ping")
+    }
+
+}

--- a/iOS/second-hand/second-hand/Network/SocketManager.swift
+++ b/iOS/second-hand/second-hand/Network/SocketManager.swift
@@ -22,6 +22,7 @@ class SocketManager {
     
     func disconnect() {
         socketClient.disconnect()
+        //unsubscribe는 disconnect 이전에 한번 해주자.
     }
     
 }


### PR DESCRIPTION
- 해당 아이템에 '나'와 연관된 채팅방이 있는지 조회하는 요청 
- '나'와 연관된 채팅방이 없을 시엔 채팅방 생성 흐름으로 , 이미 존재할 경우엔 채팅방 입장흐름으로 구현 
- 채팅방 컨트롤러 구현 
   - BE로부터 받은 데이터들을 뷰컨트롤러에 땡겨온 뒤 viewLoad를 진행한다. 
   - 이러면 이미 데이터들이 fetch 되어 있기 때문에 뷰를 그릴때 바로 사용할 수 있다. 
   - 상단 버튼과 상대방 아이디를 view에 적용 시켰다.  