### PR TITLE
FEAT: 웹소켓 CONNECT 시 유저 확인 및 특정 이벤트 발생 

### DIFF
--- a/backend/src/main/java/com/team5/secondhand/chat/bubble/config/WebSocketMessageBroker.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/bubble/config/WebSocketMessageBroker.java
@@ -37,7 +37,7 @@ public class WebSocketMessageBroker implements WebSocketMessageBrokerConfigurer 
             @Override
             public Message<?> preSend(Message<?> message, MessageChannel channel) {
                 StompHeaderAccessor headerAccessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
-                log.debug("stomp command : {} , destination {}", headerAccessor.getCommand(), headerAccessor.getDestination());
+                log.debug("stomp command : {} , destination :  {} , sessionId : {}", headerAccessor.getCommand(), headerAccessor.getDestination(), headerAccessor.getSessionId());
                 return message;
             }
         });

--- a/backend/src/main/java/com/team5/secondhand/chat/bubble/config/WebSocketMessageBroker.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/bubble/config/WebSocketMessageBroker.java
@@ -1,11 +1,19 @@
 package com.team5.secondhand.chat.bubble.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+@Slf4j
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketMessageBroker implements WebSocketMessageBrokerConfigurer {
@@ -21,5 +29,17 @@ public class WebSocketMessageBroker implements WebSocketMessageBrokerConfigurer 
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/sub"); // 구독 요청
         registry.setApplicationDestinationPrefixes("/pub"); // 발행
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(new ChannelInterceptor() {
+            @Override
+            public Message<?> preSend(Message<?> message, MessageChannel channel) {
+                StompHeaderAccessor headerAccessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+                log.debug("stomp command : {} , destination {}", headerAccessor.getCommand(), headerAccessor.getDestination());
+                return message;
+            }
+        });
     }
 }

--- a/backend/src/main/java/com/team5/secondhand/chat/bubble/domain/MessageType.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/bubble/domain/MessageType.java
@@ -1,5 +1,0 @@
-package com.team5.secondhand.chat.bubble.domain;
-
-public enum MessageType {
-    ENTER, TEXT;
-}

--- a/backend/src/main/java/com/team5/secondhand/chat/chatroom/handler/StompErrorHandler.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/chatroom/handler/StompErrorHandler.java
@@ -1,0 +1,31 @@
+package com.team5.secondhand.chat.chatroom.handler;
+
+import com.team5.secondhand.chat.exception.ErrorType;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+import java.nio.charset.StandardCharsets;
+
+@Configuration
+public class StompErrorHandler extends StompSubProtocolErrorHandler {
+    @Override
+    public Message<byte[]> handleClientMessageProcessingError(Message<byte[]> clientMessage, Throwable ex) {
+        ErrorType errorType = ErrorType.of(ex.getMessage());
+        if (errorType == ErrorType.DEFAULT) {
+            return super.handleClientMessageProcessingError(clientMessage, ex);
+        }
+
+        return errorMessage(errorType.getErrorMessage());
+    }
+
+    private Message<byte[]> errorMessage(String errorMessage) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
+        accessor.setLeaveMutable(true);
+
+        return MessageBuilder.createMessage(errorMessage.getBytes(StandardCharsets.UTF_8), accessor.getMessageHeaders());
+    }
+}

--- a/backend/src/main/java/com/team5/secondhand/chat/chatroom/handler/StompMessageProcessor.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/chatroom/handler/StompMessageProcessor.java
@@ -1,8 +1,12 @@
 package com.team5.secondhand.chat.chatroom.handler;
 
+import com.team5.secondhand.chat.exception.ErrorType;
+import com.team5.secondhand.global.jwt.service.JwtService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
@@ -11,12 +15,44 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class StompMessageProcessor implements ChannelInterceptor {
+    private final JwtService jwtService;
+
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor headerAccessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
         log.debug("stomp command : {} , destination :  {} , sessionId : {}", headerAccessor.getCommand(), headerAccessor.getDestination(), headerAccessor.getSessionId());
-
+        handleMessage(headerAccessor);
         return message;
+    }
+
+    private void handleMessage(StompHeaderAccessor headerAccessor) {
+        if (headerAccessor == null || headerAccessor.getCommand() == null) {
+            throw new MessageDeliveryException(ErrorType.BAD_REQUEST.getMessage());
+        }
+
+        switch (headerAccessor.getCommand()) {
+            case CONNECT:
+                String memberId = getMemberIdByToken(headerAccessor.getFirstNativeHeader("Authorization"));
+                enterToChatRoom(headerAccessor, memberId);
+                break;
+            case SUBSCRIBE:
+            case SEND:
+            default:
+                break;
+        }
+    }
+
+    private String getMemberIdByToken(String authorization) {
+        if (authorization == null) {
+            throw new MessageDeliveryException(ErrorType.UNAUTHORIZED.getMessage());
+        }
+
+        return jwtService.getMemberId(authorization).orElseThrow(() -> new MessageDeliveryException(ErrorType.UNAUTHORIZED.getMessage()));
+    }
+
+    private void enterToChatRoom(StompHeaderAccessor headerAccessor, String memberId) {
+        //todo: redis에 현재 존재하는 멤버 저장
     }
 }

--- a/backend/src/main/java/com/team5/secondhand/chat/chatroom/handler/StompMessageProcessor.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/chatroom/handler/StompMessageProcessor.java
@@ -1,0 +1,22 @@
+package com.team5.secondhand.chat.chatroom.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+
+@Component
+@Slf4j
+public class StompMessageProcessor implements ChannelInterceptor {
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor headerAccessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        log.debug("stomp command : {} , destination :  {} , sessionId : {}", headerAccessor.getCommand(), headerAccessor.getDestination(), headerAccessor.getSessionId());
+
+        return message;
+    }
+}

--- a/backend/src/main/java/com/team5/secondhand/chat/config/WebSocketMessageBroker.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/config/WebSocketMessageBroker.java
@@ -15,8 +15,10 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 @Slf4j
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSocketMessageBroker
 public class WebSocketMessageBroker implements WebSocketMessageBrokerConfigurer {
+    private final StompMessageProcessor stompMessageProcessor;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -33,13 +35,6 @@ public class WebSocketMessageBroker implements WebSocketMessageBrokerConfigurer 
 
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
-        registration.interceptors(new ChannelInterceptor() {
-            @Override
-            public Message<?> preSend(Message<?> message, MessageChannel channel) {
-                StompHeaderAccessor headerAccessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
-                log.debug("stomp command : {} , destination :  {} , sessionId : {}", headerAccessor.getCommand(), headerAccessor.getDestination(), headerAccessor.getSessionId());
-                return message;
-            }
-        });
+        registration.interceptors(stompMessageProcessor);
     }
 }

--- a/backend/src/main/java/com/team5/secondhand/chat/config/WebSocketMessageBroker.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/config/WebSocketMessageBroker.java
@@ -1,14 +1,12 @@
-package com.team5.secondhand.chat.bubble.config;
+package com.team5.secondhand.chat.config;
 
+import com.team5.secondhand.chat.chatroom.handler.StompErrorHandler;
+import com.team5.secondhand.chat.chatroom.handler.StompMessageProcessor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
-import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
-import org.springframework.messaging.support.ChannelInterceptor;
-import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
@@ -19,12 +17,13 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @EnableWebSocketMessageBroker
 public class WebSocketMessageBroker implements WebSocketMessageBrokerConfigurer {
     private final StompMessageProcessor stompMessageProcessor;
+    private final StompErrorHandler stompErrorHandler;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/chat")
                 .setAllowedOrigins("*");
-//                .addInterceptors() //? 세션을 intercepter 에서 등록해주는 것인가?
+        registry.setErrorHandler(stompErrorHandler);
     }
 
     @Override

--- a/backend/src/main/java/com/team5/secondhand/chat/exception/ErrorType.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/exception/ErrorType.java
@@ -1,0 +1,35 @@
+package com.team5.secondhand.chat.exception;
+
+public enum ErrorType {
+    UNAUTHORIZED("unauthorized", "채팅을 연결할 수 없습니다. 로그인을 다시 시도해주세요."),
+    BAD_REQUEST("bad request", "요청이 잘못되었습니다."),
+    DEFAULT("default", "기존 stomp 에러 타입");
+
+    private final String message;
+    private final String errorMessage;
+
+
+    ErrorType(String message, String errorMessage) {
+        this.message = message;
+        this.errorMessage = errorMessage;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public static ErrorType of(String message) {
+        for (ErrorType errorType : ErrorType.values()) {
+            if (errorType.message.equals(message)) {
+                return errorType;
+            }
+        }
+        return DEFAULT;
+    }
+
+
+}

--- a/backend/src/main/java/com/team5/secondhand/global/jwt/service/JwtService.java
+++ b/backend/src/main/java/com/team5/secondhand/global/jwt/service/JwtService.java
@@ -1,17 +1,25 @@
 package com.team5.secondhand.global.jwt.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team5.secondhand.api.member.dto.response.MemberDetails;
 import com.team5.secondhand.global.jwt.util.JwtProperties;
 import com.team5.secondhand.global.jwt.util.JwtUtils;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class JwtService {
+    private final ObjectMapper objectMapper;
     private final JwtUtils jwtUtils;
     private final JwtProperties jwtProperties;
 
@@ -22,4 +30,22 @@ public class JwtService {
         return token;
     }
 
+    public Optional<String> getMemberId(String authorization) {
+        try {
+            String token = getToken(authorization);
+            Claims claim = jwtUtils.getClaim(token);
+            MemberDetails loginMember = objectMapper.readValue((String) claim.get(jwtProperties.getClaimKey()), MemberDetails.class);
+            
+            return Optional.of(loginMember.getMemberId());
+        } catch (JsonProcessingException e) {
+            log.error("stomp JsonProcessingException");
+        } catch (JwtException e) {
+            log.error("stomp JwtException");
+        }
+        return Optional.empty();
+    }
+
+    private String getToken(String authorization) {
+        return authorization.split(" ")[1];
+    }
 }


### PR DESCRIPTION
## 구현사항
- 웹소켓 connect 시 `Authorization` 헤더에 있는 토큰 검증
- 올바르지 않은 토큰일 경우 & 헤더가 없을 경우 에러메시지 보내기 + connect 하지 못하도록 구현
   - `StompSubProtocolErrorHandler` 를 상속받아 `handleClientMessageProcessingError` 오버라이드하여 구현
   - 에러 메시지를 보내고 내부적으로 disconnect 를 하여 connect 를 하지 못하도록 동작

## 고민 사항
- 현재 connect 시 토큰 검증을 하는데 subcribe 과 send 하는 요청에도 토큰 검증을 진행해야 하는 것인지 고민이 됩니다.
- 현재 토큰 검증만 진행하고 있는데 실제 멤버가 알맞은 채팅방에 connect 요청을 보냈는지에 대한 부분도 검증을 진행해야할 지 고민 됩니다. 
   - 그렇다면 mysql 에 저장되어 있는 `chatroom` 정보를 조회하여 검증하는 방법밖에 없을까요? 

## 추후 수정 사항
- connect 시 채팅방에 입장했다는 것을 저장하도록 생각했는데 connect 시에는 입장하는 채팅방을 알 수 없어 subscribe 할 때 채팅방에 입장했다는 것을 저장해야 할 것 같습니다. (SSE 알람을 보낼 때 사용할 정보) 
   - send 하기 전에 subscribe 를 하는 구조라 가능할 것 같습니다.