### PR TITLE
iOS - 홈뷰 버그 픽스 

### DIFF
--- a/iOS/second-hand/second-hand.xcodeproj/project.pbxproj
+++ b/iOS/second-hand/second-hand.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		E473CD1C2A88BAD600981BAF /* ChatroomListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E473CD1B2A88BAD600981BAF /* ChatroomListModel.swift */; };
 		E473CD1F2A8A1DCE00981BAF /* TextSectionViewInChatroomListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E473CD1E2A8A1DCE00981BAF /* TextSectionViewInChatroomListCell.swift */; };
 		E473CD222A8F463000981BAF /* ScrollActionDelagate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E473CD212A8F463000981BAF /* ScrollActionDelagate.swift */; };
+		E473CD242A9484E600981BAF /* statusPriceStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E473CD232A9484E600981BAF /* statusPriceStackView.swift */; };
 		E4923CDD2A6FA02600D2BF19 /* ItemSummaryInChatroom.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4923CDC2A6FA02600D2BF19 /* ItemSummaryInChatroom.swift */; };
 		E4987E452A4D9F7600337543 /* Int,String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4987E442A4D9F7600337543 /* Int,String+Extension.swift */; };
 		E49EB8342A2DB498001F2D56 /* SecondHandTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49EB8332A2DB498001F2D56 /* SecondHandTabBarController.swift */; };
@@ -152,6 +153,7 @@
 		E473CD1B2A88BAD600981BAF /* ChatroomListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ChatroomListModel.swift; path = "second-hand/Chatting/Model/ChatroomListModel.swift"; sourceTree = SOURCE_ROOT; };
 		E473CD1E2A8A1DCE00981BAF /* TextSectionViewInChatroomListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextSectionViewInChatroomListCell.swift; sourceTree = "<group>"; };
 		E473CD212A8F463000981BAF /* ScrollActionDelagate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollActionDelagate.swift; sourceTree = "<group>"; };
+		E473CD232A9484E600981BAF /* statusPriceStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = statusPriceStackView.swift; sourceTree = "<group>"; };
 		E4923CDC2A6FA02600D2BF19 /* ItemSummaryInChatroom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemSummaryInChatroom.swift; sourceTree = "<group>"; };
 		E4987E442A4D9F7600337543 /* Int,String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int,String+Extension.swift"; sourceTree = "<group>"; };
 		E49EB8332A2DB498001F2D56 /* SecondHandTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondHandTabBarController.swift; sourceTree = "<group>"; };
@@ -673,6 +675,7 @@
 				E49EB8552A306E68001F2D56 /* ButtonCustomView.swift */,
 				E49EB8532A30690F001F2D56 /* HomeRightBarButton.swift */,
 				DBEA32802A4101B400C04E0A /* ProductListCollectionViewCell.swift */,
+				E473CD232A9484E600981BAF /* statusPriceStackView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -989,6 +992,7 @@
 				DB55CB132A44186E00578ED5 /* UITextField+Extension.swift in Sources */,
 				DBEA32812A4101B400C04E0A /* ProductListCollectionViewCell.swift in Sources */,
 				E4C951502A3AFF9B0094AD66 /* CodableTemplate.swift in Sources */,
+				E473CD242A9484E600981BAF /* statusPriceStackView.swift in Sources */,
 				DBDF80042A39BC6E007B3E01 /* GithubWebViewController.swift in Sources */,
 				DBAF83B22A32E3E900194A02 /* NotLoginMyAccountViewController.swift in Sources */,
 			);

--- a/iOS/second-hand/second-hand.xcodeproj/project.pbxproj
+++ b/iOS/second-hand/second-hand.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		E473CD1C2A88BAD600981BAF /* ChatroomListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E473CD1B2A88BAD600981BAF /* ChatroomListModel.swift */; };
 		E473CD1F2A8A1DCE00981BAF /* TextSectionViewInChatroomListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E473CD1E2A8A1DCE00981BAF /* TextSectionViewInChatroomListCell.swift */; };
 		E473CD222A8F463000981BAF /* ScrollActionDelagate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E473CD212A8F463000981BAF /* ScrollActionDelagate.swift */; };
-		E473CD242A9484E600981BAF /* statusPriceStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E473CD232A9484E600981BAF /* statusPriceStackView.swift */; };
+		E473CD242A9484E600981BAF /* StatusPriceStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E473CD232A9484E600981BAF /* StatusPriceStackView.swift */; };
 		E4923CDD2A6FA02600D2BF19 /* ItemSummaryInChatroom.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4923CDC2A6FA02600D2BF19 /* ItemSummaryInChatroom.swift */; };
 		E4987E452A4D9F7600337543 /* Int,String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4987E442A4D9F7600337543 /* Int,String+Extension.swift */; };
 		E49EB8342A2DB498001F2D56 /* SecondHandTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49EB8332A2DB498001F2D56 /* SecondHandTabBarController.swift */; };
@@ -153,7 +153,7 @@
 		E473CD1B2A88BAD600981BAF /* ChatroomListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ChatroomListModel.swift; path = "second-hand/Chatting/Model/ChatroomListModel.swift"; sourceTree = SOURCE_ROOT; };
 		E473CD1E2A8A1DCE00981BAF /* TextSectionViewInChatroomListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextSectionViewInChatroomListCell.swift; sourceTree = "<group>"; };
 		E473CD212A8F463000981BAF /* ScrollActionDelagate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollActionDelagate.swift; sourceTree = "<group>"; };
-		E473CD232A9484E600981BAF /* statusPriceStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = statusPriceStackView.swift; sourceTree = "<group>"; };
+		E473CD232A9484E600981BAF /* StatusPriceStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusPriceStackView.swift; sourceTree = "<group>"; };
 		E4923CDC2A6FA02600D2BF19 /* ItemSummaryInChatroom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemSummaryInChatroom.swift; sourceTree = "<group>"; };
 		E4987E442A4D9F7600337543 /* Int,String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int,String+Extension.swift"; sourceTree = "<group>"; };
 		E49EB8332A2DB498001F2D56 /* SecondHandTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondHandTabBarController.swift; sourceTree = "<group>"; };
@@ -675,7 +675,7 @@
 				E49EB8552A306E68001F2D56 /* ButtonCustomView.swift */,
 				E49EB8532A30690F001F2D56 /* HomeRightBarButton.swift */,
 				DBEA32802A4101B400C04E0A /* ProductListCollectionViewCell.swift */,
-				E473CD232A9484E600981BAF /* statusPriceStackView.swift */,
+				E473CD232A9484E600981BAF /* StatusPriceStackView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -992,7 +992,7 @@
 				DB55CB132A44186E00578ED5 /* UITextField+Extension.swift in Sources */,
 				DBEA32812A4101B400C04E0A /* ProductListCollectionViewCell.swift in Sources */,
 				E4C951502A3AFF9B0094AD66 /* CodableTemplate.swift in Sources */,
-				E473CD242A9484E600981BAF /* statusPriceStackView.swift in Sources */,
+				E473CD242A9484E600981BAF /* StatusPriceStackView.swift in Sources */,
 				DBDF80042A39BC6E007B3E01 /* GithubWebViewController.swift in Sources */,
 				DBAF83B22A32E3E900194A02 /* NotLoginMyAccountViewController.swift in Sources */,
 			);

--- a/iOS/second-hand/second-hand/Home/View/ProductListCollectionViewCell.swift
+++ b/iOS/second-hand/second-hand/Home/View/ProductListCollectionViewCell.swift
@@ -28,12 +28,14 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        layout()
         
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+    }
+    
+    override func layoutSubviews() {
         layout()
     }
     
@@ -99,9 +101,18 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
     }
     
     private func layout() {
-        [thumbnailImage, title, location, dot, registerTime, statusLabel, price, line].forEach{
+        guard let statusAndPriceStackView = statusAndPriceStackView else {
+            return
+        }
+        
+        [thumbnailImage, title, location, dot, registerTime, line].forEach{
             self.contentView.addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        if !self.contentView.contains(statusAndPriceStackView) {
+            self.contentView.addSubview(statusAndPriceStackView)
+            statusAndPriceStackView.translatesAutoresizingMaskIntoConstraints = false
         }
         
         let height: CGFloat = self.frame.height
@@ -129,13 +140,9 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
             registerTime.leadingAnchor.constraint(equalTo: dot.trailingAnchor),
             registerTime.topAnchor.constraint(equalTo: dot.topAnchor),
             
-            statusLabel.leadingAnchor.constraint(equalTo: location.leadingAnchor),
-            statusLabel.topAnchor.constraint(equalTo: location.bottomAnchor, constant: 4*heightRatio),
-            statusLabel.heightAnchor.constraint(equalToConstant: 22),
-            statusLabel.widthAnchor.constraint(equalToConstant: round(50*widthRatio)),
-            
-            price.topAnchor.constraint(equalTo: statusLabel.topAnchor),
-            price.leadingAnchor.constraint(equalTo: statusLabel.trailingAnchor, constant: round(4*widthRatio)),
+            statusAndPriceStackView.leadingAnchor.constraint(equalTo: location.leadingAnchor),
+            statusAndPriceStackView.topAnchor.constraint(equalTo: location.bottomAnchor, constant: 4*heightRatio),
+            statusAndPriceStackView.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor),
             
             line.bottomAnchor.constraint(equalTo: self.bottomAnchor),
             line.heightAnchor.constraint(equalToConstant: 1),

--- a/iOS/second-hand/second-hand/Home/View/ProductListCollectionViewCell.swift
+++ b/iOS/second-hand/second-hand/Home/View/ProductListCollectionViewCell.swift
@@ -17,8 +17,7 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
     private let dot = UILabel()
     let registerTime = UILabel()
     
-    let statusLabel = UILabel()
-    let price = UILabel()
+    private var statusAndPriceStackView : StatusPriceStackView? = nil
     
     let chatCount = UILabel()
     let wishCount = UILabel()
@@ -44,9 +43,16 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
         setLocation(item.region)
         setDot()
         setRegisterTime(item.createdAt)
-        setStatusLabel(item.status)
-        setPrice(item.price)
+        if let stackView = statusAndPriceStackView {
+            stackView.updateStatusAndPrice(status: item.status, price: item.price)
+        } else {
+            setStackView(item.status, item.price)
+        }
         setLine()
+    }
+    
+    private func setStackView(_ status : Int, _ price : Int ) {
+        self.statusAndPriceStackView = StatusPriceStackView(status: status, price: price)
     }
     
     private func setImageView(url: String) {
@@ -82,46 +88,12 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
         registerTime.text = time.convertToRelativeTime()
     }
     
-    private func setStatusLabel(_ status: Int) {
-        switch status {
-        case 1:
-            statusLabel.text = "예약중"
-            statusLabel.backgroundColor = .accentBackgroundSecondary
-        case 2:
-            statusLabel.text = "판매완료"
-            statusLabel.backgroundColor = .gray
-        default :
-            statusLabel.widthAnchor.constraint(equalToConstant: round(0)).isActive = true
-            
-            price.leadingAnchor.constraint(equalTo: statusLabel.trailingAnchor).isActive = true
-            
-            statusLabel.text = ""
-            
-        }
-        statusLabel.textAlignment = .center
-        statusLabel.font = .fontA
-        statusLabel.textColor = .accentText
-        
-        statusLabel.layer.masksToBounds = true
-        statusLabel.layer.cornerRadius = 8
-    }
-    
-    private func setPrice(_ num : Int) {
-        let monetary = num.convertToMonetary()
-        price.text = "\(monetary)원"
-        price.font = .headLine
-        price.textColor = .neutralTextStrong
-    }
-    
-    
-    
     private func setLine() {
         line.backgroundColor = .neutralBorder
     }
     
     func configure(title: String, price: String, location: String, registerTime: String) {
         self.title.text = title
-        self.price.text = price
         self.location.text = location
         self.registerTime.text = registerTime
     }

--- a/iOS/second-hand/second-hand/Home/View/StatusPriceStackView.swift
+++ b/iOS/second-hand/second-hand/Home/View/StatusPriceStackView.swift
@@ -24,6 +24,30 @@ class StatusPriceStackView: UIStackView {
     required init(coder: NSCoder) {
         super.init(coder: coder)
     }
-
-
+    
+    private func setStatusLabel(_ status: Int) {
+        switch status {
+        case 1:
+            statusLabel.text = " 예약중 "
+            statusLabel.backgroundColor = .accentBackgroundSecondary
+            statusLabel.isHidden = false
+        case 2:
+            statusLabel.text = " 판매완료 "
+            statusLabel.backgroundColor = .gray
+            statusLabel.isHidden = false
+            
+        default :
+            statusLabel.isHidden = true
+            
+        }
+        statusLabel.textAlignment = .justified
+        statusLabel.font = .fontA
+        statusLabel.textColor = .accentText
+        
+        statusLabel.layer.masksToBounds = true
+        statusLabel.layer.cornerRadius = 8
+        
+        statusLabel.sizeToFit()
+    }
+    
 }

--- a/iOS/second-hand/second-hand/Home/View/StatusPriceStackView.swift
+++ b/iOS/second-hand/second-hand/Home/View/StatusPriceStackView.swift
@@ -50,4 +50,17 @@ class StatusPriceStackView: UIStackView {
         statusLabel.sizeToFit()
     }
     
+    private func setPriceLabel(_ price: Int) {
+        let monetary = price.convertToMonetary()
+        priceLabel.text = "\(monetary)원"
+        priceLabel.font = .headLine
+        priceLabel.textColor = .neutralTextStrong
+        
+        priceLabel.sizeToFit()
+    }
+    
+    func updateStatusAndPrice(status:Int,price:Int) {
+        setStatusLabel(status)
+        setPriceLabel(price)
+    }
 }

--- a/iOS/second-hand/second-hand/Home/View/StatusPriceStackView.swift
+++ b/iOS/second-hand/second-hand/Home/View/StatusPriceStackView.swift
@@ -8,6 +8,22 @@
 import UIKit
 
 class StatusPriceStackView: UIStackView {
+    private var statusLabel = UILabel()
+    private var priceLabel = UILabel()
+    private var emptyView = UIView()
+    
+    init(status:Int, price:Int) {
+        super.init(frame: .zero)
+        self.spacing = 5.0
+        
+        setStatusLabel(status)
+        setPriceLabel(price)
+        setLayout()
+    }
+    
+    required init(coder: NSCoder) {
+        super.init(coder: coder)
+    }
 
 
 }

--- a/iOS/second-hand/second-hand/Home/View/StatusPriceStackView.swift
+++ b/iOS/second-hand/second-hand/Home/View/StatusPriceStackView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class statusPriceStackView: UIStackView {
+class StatusPriceStackView: UIStackView {
 
 
 }

--- a/iOS/second-hand/second-hand/Home/View/StatusPriceStackView.swift
+++ b/iOS/second-hand/second-hand/Home/View/StatusPriceStackView.swift
@@ -18,7 +18,7 @@ class StatusPriceStackView: UIStackView {
         
         setStatusLabel(status)
         setPriceLabel(price)
-        setLayout()
+        setSubViews()
     }
     
     required init(coder: NSCoder) {
@@ -62,5 +62,18 @@ class StatusPriceStackView: UIStackView {
     func updateStatusAndPrice(status:Int,price:Int) {
         setStatusLabel(status)
         setPriceLabel(price)
+    }
+    
+    private func setSubviews() {
+        if !self.contains(statusLabel) {
+            self.addArrangedSubview(statusLabel)
+        }
+        
+        if !self.contains(priceLabel) {
+            self.addArrangedSubview(priceLabel)
+            self.addArrangedSubview(UIView())
+        }
+
+
     }
 }

--- a/iOS/second-hand/second-hand/Home/View/StatusPriceStackView.swift
+++ b/iOS/second-hand/second-hand/Home/View/StatusPriceStackView.swift
@@ -18,7 +18,7 @@ class StatusPriceStackView: UIStackView {
         
         setStatusLabel(status)
         setPriceLabel(price)
-        setSubViews()
+        setSubviews()
     }
     
     required init(coder: NSCoder) {

--- a/iOS/second-hand/second-hand/Home/View/statusPriceStackView.swift
+++ b/iOS/second-hand/second-hand/Home/View/statusPriceStackView.swift
@@ -1,0 +1,13 @@
+//
+//  statusPriceStackView.swift
+//  second-hand
+//
+//  Created by SONG on 2023/08/22.
+//
+
+import UIKit
+
+class statusPriceStackView: UIStackView {
+
+
+}


### PR DESCRIPTION
## 주요 작업 내용 
- itemList의 cell이 reuse될 때, status Label이 사라지는 버그 수정 

## 해결과정 
### - status값에 따라서 판매중 / 판매완료 / 예약중을 나타내는 조건 분기 수정 

   -> 기존의 조건분기 흐름은 예약중, 판매완료 일 때는 해당 view의 widthAnchor를 건드리는 방식
   기존의 방식은 cell이 reuse될 때 정상적으로 적용이 되지 않음. 예약중 , 판매완료 임에도 불구하고 cell이 reuse되면 라벨이 사라지는 현상 발생 , widthAnchor를 조절하는 방식은 reuse 될 때의 라이프사이클에 정상적으로 적용되지 않게 코드를 짰다고 판단, 문제가 되는 뷰들을 묶어서 스택뷰로 표시하는 방법으로 수정 
 
### - 스택뷰 중첩 문제 

   -> 스택뷰로 묶어놓으니 , 라벨이 사라지지는 않으나, reuse 될 때 중첩되어 표시되는 상황 발생. 디버깅 결과 UI세팅과정에서 매번 생성하는 것을 발견, 아래와 같이 조건적으로 생성하도록 수정  
   ``` 
       func setUI(from item : SellingItem) {
        setImageView(url: item.thumbnailImageUrl)
        setTitle(item.title)
        setLocation(item.region)
        setDot()
        setRegisterTime(item.createdAt)
        if let stackView = statusAndPriceStackView {
            stackView.updateStatusAndPrice(status: item.status, price: item.price)
        } else {
            setStackView(item.status, item.price)
        }
        setLine()
    }
   ```
