### PR TITLE
iOS- 채팅 알림 구독 

### DIFF
--- a/iOS/second-hand/second-hand/CategoryViewController.swift
+++ b/iOS/second-hand/second-hand/CategoryViewController.swift
@@ -67,7 +67,7 @@ class CategoryViewController: UIViewController {
     }
     
     private func sendGet() {
-        NetworkManager.sendGET(decodeType: CategoryData.self, what: nil, fromURL: URL(string: Server.shared.url(for: .resourceCategories))!) { (result: Result<[CategoryData], Error>) in
+        NetworkManager.sendGET(decodeType: CategoryData.self,header: nil, body: nil, fromURL: URL(string: Server.shared.url(for: .resourceCategories))!) { (result: Result<[CategoryData], Error>) in
             switch result {
             case .success(let data) :
                 self.categoryList = data

--- a/iOS/second-hand/second-hand/Chatting/Controller/ChattingViewController.swift
+++ b/iOS/second-hand/second-hand/Chatting/Controller/ChattingViewController.swift
@@ -45,13 +45,7 @@ final class ChattingViewController: NavigationUnderLineViewController {
             }
         }
     }
-    
-//    private func fetchChatroomListDataAndMakeTableView(completion: @escaping () -> Void) {
-//        fetchChatroomListData {
-//            completion()
-//        }
-//    }
-    
+
     private func fetchChatroomListData(isInitialize: Bool, completion: @escaping () -> Void) {
         if isInitialize {
             self.isLastPage = false
@@ -63,7 +57,7 @@ final class ChattingViewController: NavigationUnderLineViewController {
             return
         }
         
-        NetworkManager.sendGET(decodeType: ChatroomListSuccess.self, what: nil, fromURL: url) { (result: Result<[ChatroomListSuccess], Error>) in
+        NetworkManager.sendGET(decodeType: ChatroomListSuccess.self,header: nil, body: nil, fromURL: url) { (result: Result<[ChatroomListSuccess], Error>) in
             switch result {
             case .success(let response) :
                 guard let chatroomListPage = response.last?.data.chatRooms else {
@@ -129,7 +123,7 @@ extension ChattingViewController: ButtonActionDelegate {
             return
         }
         
-        NetworkManager.sendGET(decodeType: ChatroomSuccess.self, what: nil, fromURL: url) { (result: Result<[ChatroomSuccess], Error>) in
+        NetworkManager.sendGET(decodeType: ChatroomSuccess.self,header: nil, body: nil, fromURL: url) { (result: Result<[ChatroomSuccess], Error>) in
             switch result {
             case .success(let response) :
                 guard let response = response.last else {

--- a/iOS/second-hand/second-hand/Chatting/Controller/ChattingViewController.swift
+++ b/iOS/second-hand/second-hand/Chatting/Controller/ChattingViewController.swift
@@ -144,31 +144,6 @@ extension ChattingViewController: ButtonActionDelegate {
         }
     }
     
-    //    private func enterChatroom(index: Int) {
-    //        let itemId = chatroomListModel.info[index].item.itemId
-    //
-    //        guard let url = URL(string: Server.shared.requestIsExistChattingRoom(itemId: itemId)) else {
-    //            return
-    //        }
-    //
-    //        guard let requestBody = JSONCreater().createOpenChatroomRequestBody(itemId: itemId) else {
-    //            return
-    //        }
-    //
-    //        NetworkManager.sendGET(decodeType: ChatroomSuccess.self, what: nil, fromURL: url) { (result: Result<[ChatroomSuccess], Error>) in
-    //            switch result {
-    //            case .success(let reposonse) :
-    //                guard let response = reposonse.last else {
-    //                    return
-    //                }
-    //                self.changeToChatroomViewController(fetchedData: response)
-    //
-    //            case .failure(let error) :
-    //                print(error.localizedDescription)
-    //            }
-    //        }
-    //    }
-    
     private func changeToChatroomViewController(fetchedData: ChatroomSuccess) {
         
         let privateChatroom = PrivateChatroomViewController()

--- a/iOS/second-hand/second-hand/Chatting/Model/ChatroomListModel.swift
+++ b/iOS/second-hand/second-hand/Chatting/Model/ChatroomListModel.swift
@@ -31,7 +31,7 @@ class ChatroomListModel: Updatable {
                         self.info.append(chatroom)
                     }
                     count += 1
-                    if count + 1 == chatrooms.count {
+                    if count == chatrooms.count {
                         completion()
                     }
                 }

--- a/iOS/second-hand/second-hand/Chatting/Model/ChatroomListModel.swift
+++ b/iOS/second-hand/second-hand/Chatting/Model/ChatroomListModel.swift
@@ -52,7 +52,7 @@ class ChatroomListModel: Updatable {
             return
         }
         
-        NetworkManager.sendGET(decodeType: ChatroomSuccess.self, what: nil, fromURL: url) { (result: Result<[ChatroomSuccess], Error>) in
+        NetworkManager.sendGET(decodeType: ChatroomSuccess.self,header: nil, body: nil, fromURL: url) { (result: Result<[ChatroomSuccess], Error>) in
             switch result {
             case .success(let reposonse) :
                 guard let response = reposonse.last else {

--- a/iOS/second-hand/second-hand/Chatting/View/CellOfChatroomList.swift
+++ b/iOS/second-hand/second-hand/Chatting/View/CellOfChatroomList.swift
@@ -21,9 +21,9 @@ class CellOfChatroomList: UITableViewCell {
         
         setOpponentPhoto(img:chatroomList.opponent.profileImgUrl)
         
-        setTextSection(opponeneId: chatroomList.opponent.memberId, time: chatroomList.chatLogs?.updatedAt ?? "", lastMessage: chatroomList.chatLogs?.lastMessage ?? "last Message")
+        setTextSection(opponeneId: chatroomList.opponent.memberId, time: chatroomList.chatLogs.updatedAt ?? "", lastMessage: chatroomList.chatLogs.lastMessage ?? "last Message")
         
-        setNumberBadge(number: chatroomList.chatLogs?.unReadCount ?? 7)
+        setNumberBadge(number: chatroomList.chatLogs.unReadCount ?? 7)
         
         setItemPhoto(img: chatroomList.item.thumbnailImgUrl)
     }

--- a/iOS/second-hand/second-hand/Chatting/subScene/PrivateChatroom/Controller/PrivateChatroomViewController.swift
+++ b/iOS/second-hand/second-hand/Chatting/subScene/PrivateChatroom/Controller/PrivateChatroomViewController.swift
@@ -285,7 +285,7 @@ class PrivateChatroomViewController: UIViewController {
             return
         }
 
-        NetworkManager.sendGET(decodeType: ChattingLog.self, what: nil, fromURL: url) { (result: Result<[ChattingLog], Error>) in
+        NetworkManager.sendGET(decodeType: ChattingLog.self,header: nil, body: nil, fromURL: url) { (result: Result<[ChattingLog], Error>) in
             switch result {
             case .success(let response) :
                 guard let response = response.last else {

--- a/iOS/second-hand/second-hand/Home/Controller/HomeViewController.swift
+++ b/iOS/second-hand/second-hand/Home/Controller/HomeViewController.swift
@@ -164,7 +164,7 @@ final class HomeViewController: NavigationUnderLineViewController{
         guard let url = URL(string: Server.shared.itemsListURL(page: page, regionID: 2729060200, category: nil)) else {
             return
         }
-        NetworkManager.sendGET(decodeType: ItemListSuccess.self, what: nil, fromURL: url) { (result: Result<[ItemListSuccess], Error>) in
+        NetworkManager.sendGET(decodeType: ItemListSuccess.self,header: nil, body: nil, fromURL: url) { (result: Result<[ItemListSuccess], Error>) in
             switch result {
             case .success(let response) :
                 guard let itemList = response.last?.data else {

--- a/iOS/second-hand/second-hand/Home/subScene/Category/subScene/Controller/CategoryItemListViewController.swift
+++ b/iOS/second-hand/second-hand/Home/subScene/Category/subScene/Controller/CategoryItemListViewController.swift
@@ -82,7 +82,7 @@ class CategoryItemListViewController: UIViewController {
             return
         }
         
-        NetworkManager.sendGET(decodeType: ItemListSuccess.self, what: nil, fromURL: url) { (result: Result<[ItemListSuccess], Error>) in
+        NetworkManager.sendGET(decodeType: ItemListSuccess.self, header: nil, body: nil, fromURL: url) { (result: Result<[ItemListSuccess], Error>) in
             switch result {
             case .success(let response) :
                 guard let itemList = response.last?.data else {

--- a/iOS/second-hand/second-hand/Home/subScene/ItemDetail/Controller/ItemDetailViewController.swift
+++ b/iOS/second-hand/second-hand/Home/subScene/ItemDetail/Controller/ItemDetailViewController.swift
@@ -88,7 +88,7 @@ class ItemDetailViewController: UIViewController {
             return
         }
         
-        NetworkManager.sendGET(decodeType: ItemDetailInfoSuccess.self, what: nil, fromURL: url) { (result: Result<[ItemDetailInfoSuccess], Error>) in
+        NetworkManager.sendGET(decodeType: ItemDetailInfoSuccess.self,header: nil, body: nil, fromURL: url) { (result: Result<[ItemDetailInfoSuccess], Error>) in
             switch result {
             case .success(let data) :
                 guard let detailInfo = data.last else {
@@ -373,7 +373,7 @@ extension ItemDetailViewController : ButtonActionDelegate {
                 return
             }
             
-            NetworkManager.sendGET(decodeType: ChatroomSuccess.self, what: nil, fromURL: url) { (result: Result<[ChatroomSuccess], Error>) in
+            NetworkManager.sendGET(decodeType: ChatroomSuccess.self,header: nil, body: nil, fromURL: url) { (result: Result<[ChatroomSuccess], Error>) in
                 switch result {
                 case .success(let reposonse) :
                     guard let response = reposonse.last else {
@@ -401,7 +401,7 @@ extension ItemDetailViewController : ButtonActionDelegate {
             return
         }
         
-        NetworkManager.sendGET(decodeType: ChatroomSuccess.self, what: nil, fromURL: url) { (result: Result<[ChatroomSuccess], Error>) in
+        NetworkManager.sendGET(decodeType: ChatroomSuccess.self,header: nil, body: nil, fromURL: url) { (result: Result<[ChatroomSuccess], Error>) in
             switch result {
             case .success(let response) :
                 guard let response = response.last else {

--- a/iOS/second-hand/second-hand/MyAccount/Controller/NotLoginMyAccountViewController.swift
+++ b/iOS/second-hand/second-hand/MyAccount/Controller/NotLoginMyAccountViewController.swift
@@ -186,12 +186,12 @@ final class NotLoginMyAccountViewController: NavigationUnderLineViewController {
             return
         }
         
-        NetworkManager.sendGET(decodeType: SubscribeSSESuccess.self, header: header, body: body, fromURL: url ) { (result: Result<[SubscribeSSESuccess], Error>) in
+        NetworkManager.sendGET(decodeType: SubscribeSSESuccess.self, header: header, body: nil, fromURL: url ) { (result: Result<[SubscribeSSESuccess], Error>) in
             switch result {
             case .success(let response) :
                 let data = response.last
                 print(data)
-                
+                //Request timeout Error
             case .failure(let error) :
                 print("SSE 구독 실패 \(error)")
             }
@@ -199,7 +199,6 @@ final class NotLoginMyAccountViewController: NavigationUnderLineViewController {
     }
     
     private func makeSSEHeader()-> [String:String]? {
-        //일단 lastId 도 그냥 보내자
         let authorizationKey: String = JSONCreater.headerKeyAuthorization
         
         guard let authorizationValue: String = UserInfoManager.shared.loginToken else {
@@ -214,7 +213,7 @@ final class NotLoginMyAccountViewController: NavigationUnderLineViewController {
         }
         
         let header = [authorizationKey:authorizationValue,contentTypeKey:"text/event-stream","Cache-Control": "no-store"]
-        
+        //LastEventID 아직 안넣었음. timeout Error 해결하고 넣을 예정
         return header
     }
     

--- a/iOS/second-hand/second-hand/MyAccount/Controller/NotLoginMyAccountViewController.swift
+++ b/iOS/second-hand/second-hand/MyAccount/Controller/NotLoginMyAccountViewController.swift
@@ -15,6 +15,8 @@ final class NotLoginMyAccountViewController: NavigationUnderLineViewController {
     private let githubLoginButton = UIButton()
     private let joinMembershipButton = UIButton()
     private let idInputSection = IdInputSection(frame: .zero)
+    private let networkManager = NetworkManager()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setNotLogOnUI()
@@ -148,9 +150,7 @@ final class NotLoginMyAccountViewController: NavigationUnderLineViewController {
 
     //MARK: 일반 로그인 테스트
     private func loginTest() {
-        
-        let networkManager = NetworkManager()
-        
+        //TODO: 일단 간달프로 고정
         let jsonString = """
                             {"memberId": "gandalf"}
                         """
@@ -169,6 +169,7 @@ final class NotLoginMyAccountViewController: NavigationUnderLineViewController {
                     UserInfoManager.shared.updateData(from: user.data)
                     
                     print("로그인성공  \(user)")
+                    self.subscribeSSE()
                     
                 case .failure(let error) :
                     print("로그인실패 \(error)")
@@ -177,4 +178,55 @@ final class NotLoginMyAccountViewController: NavigationUnderLineViewController {
         }
     }
 
+    //MARK: About subscribe SSE
+    private func subscribeSSE() {
+        let header = makeSSEHeader()
+        let body = makeSSEBody()
+        guard let url = URL(string: makeSSEURL()) else {
+            return
+        }
+        
+        NetworkManager.sendGET(decodeType: SubscribeSSESuccess.self, header: header, body: body, fromURL: url ) { (result: Result<[SubscribeSSESuccess], Error>) in
+            switch result {
+            case .success(let response) :
+                let data = response.last
+                print(data)
+                
+            case .failure(let error) :
+                print("SSE 구독 실패 \(error)")
+            }
+        }
+    }
+    
+    private func makeSSEHeader()-> [String:String]? {
+        //일단 lastId 도 그냥 보내자
+        let authorizationKey: String = JSONCreater.headerKeyAuthorization
+        
+        guard let authorizationValue: String = UserInfoManager.shared.loginToken else {
+            return nil
+        }
+        
+        let contentTypeKey: String = JSONCreater.headerKeyContentType
+        
+        
+        guard let userInfo = UserInfoManager.shared.userInfo else {
+            return [authorizationKey:authorizationValue,contentTypeKey:"text/event-stream","Cache-Control": "no-store"]
+        }
+        
+        let header = [authorizationKey:authorizationValue,contentTypeKey:"text/event-stream","Cache-Control": "no-store"]
+        
+        return header
+    }
+    
+    private func makeSSEBody() -> Data? {
+        let body = JSONCreater().createSSESubscribeBody()
+        
+        return body
+    }
+    
+    private func makeSSEURL() -> String {
+        let url = Server.shared.createSSESubscribeURL()
+        
+        return url
+    }
 }

--- a/iOS/second-hand/second-hand/NavigationUnderLineViewController.swift
+++ b/iOS/second-hand/second-hand/NavigationUnderLineViewController.swift
@@ -13,12 +13,13 @@ class NavigationUnderLineViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        setNavigationBarBottomBorder()
+        //setNavigationBarBottomBorder()
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = UIColor.white
+        setNavigationBarBottomBorder()
     }
     
     private func setNavigationBarBottomBorder() {

--- a/iOS/second-hand/second-hand/Network/CodableTemplate.swift
+++ b/iOS/second-hand/second-hand/Network/CodableTemplate.swift
@@ -268,7 +268,7 @@ struct ChatroomList: Codable {
     let chatroomId : String
     let opponent : ChatroomListOpponent
     let item : ChatroomListItem
-    let chatLogs : ChatroomListChatLog?
+    let chatLogs : ChatroomListChatLog
 }
 
 struct ChatroomListOpponent: Codable {
@@ -284,7 +284,7 @@ struct ChatroomListItem: Codable {
 
 struct ChatroomListChatLog: Codable {
     let lastMessage: String
-    let updatedAt : String
+    let updatedAt : String?
     let unReadCount: Int
 }
 

--- a/iOS/second-hand/second-hand/Network/CodableTemplate.swift
+++ b/iOS/second-hand/second-hand/Network/CodableTemplate.swift
@@ -306,3 +306,9 @@ struct ModifyItemSuccess: Codable {
     let message: String
     let id: Int
 }
+
+struct SubscribeSSESuccess: Codable {
+    let id: String
+    let event: String
+    let data: String
+}

--- a/iOS/second-hand/second-hand/Network/JSONCreater.swift
+++ b/iOS/second-hand/second-hand/Network/JSONCreater.swift
@@ -52,4 +52,20 @@ class JSONCreater {
             return nil
         }
     }
+    
+    func createSSESubscribeBody() -> Data? {
+        guard let userInfo = UserInfoManager.shared.userInfo else {
+            return nil
+        }
+        
+        let requestBody: [String : String] = ["memberId":userInfo.memberId]
+        
+        do {
+            let jsonData = try JSONEncoder().encode(requestBody)
+            return jsonData
+        } catch {
+            print("JSON encoding error: \(error)")
+            return nil
+        }
+    }
 }

--- a/iOS/second-hand/second-hand/Network/NetworkManager.swift
+++ b/iOS/second-hand/second-hand/Network/NetworkManager.swift
@@ -122,7 +122,7 @@ class NetworkManager {
     }
     
     
-    static func sendGET<T:Codable> (decodeType:T.Type,what data :Data?, fromURL url: URL, completion: @escaping (Result<[T], Error>) -> Void) {
+    static func sendGET<T:Codable> (decodeType:T.Type, header: [String:String]? ,body data :Data?, fromURL url: URL, completion: @escaping (Result<[T], Error>) -> Void) {
         
         let asyncCompletion: (Result<[T], Error>) -> Void = { result in
             DispatchQueue.main.async {

--- a/iOS/second-hand/second-hand/Network/NetworkManager.swift
+++ b/iOS/second-hand/second-hand/Network/NetworkManager.swift
@@ -129,21 +129,25 @@ class NetworkManager {
                 completion(result)
             }
         }
-        var request = URLRequest(url: url, timeoutInterval: 60.0)
+        var request = URLRequest(url: url,timeoutInterval: 60)
         
-        
-        if let loginToken = UserInfoManager.shared.loginToken {
-            request.allHTTPHeaderFields = [JSONCreater.headerKeyContentType: JSONCreater.headerValueContentType,JSONCreater.headerKeyAuthorization: loginToken]
+        if header == nil {
+            if let loginToken = UserInfoManager.shared.loginToken {
+                request.allHTTPHeaderFields = [JSONCreater.headerKeyContentType: JSONCreater.headerValueContentType,JSONCreater.headerKeyAuthorization: loginToken]
+            } else {
+                request.allHTTPHeaderFields = [JSONCreater.headerKeyContentType: JSONCreater.headerValueContentType]
+            }
         } else {
-            request.allHTTPHeaderFields = [JSONCreater.headerKeyContentType: JSONCreater.headerValueContentType]
+            request.allHTTPHeaderFields = header
         }
         
         request.httpMethod = HttpMethod.get.rawValue
         request.httpBody = data
-        
+        // 9qns 32ch
         let task = URLSession.shared.dataTask(with: request) { data, response, error in
             do {
                 guard let data = data else {
+                    print("response is nil")
                     return
                 }
                 
@@ -232,6 +236,7 @@ class NetworkManager {
                 completion(result)
             }
         }
+        
         guard let data = data else {
             return
         }

--- a/iOS/second-hand/second-hand/Network/Server.swift
+++ b/iOS/second-hand/second-hand/Network/Server.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct Server {
     static let shared = Server()
-    static let baseURL = "http://3.37.51.148:81"
+    static let baseURL = "http://43.202.132.236:81"
     static let oAuthURL = "https://github.com/login/oauth/authorize"
     static let clientID = "5c4b10099c0ae232e5a1"
     static let redirectURL = "http://localhost:5173/login/oauth2/code/github"
@@ -28,6 +28,7 @@ struct Server {
         case status = "/status"
         case itemsImage = "/items/image"
         case logs = "/logs"
+        case subscribe = "/subscribe"
         
     }
     

--- a/iOS/second-hand/second-hand/Network/Server.swift
+++ b/iOS/second-hand/second-hand/Network/Server.swift
@@ -119,6 +119,15 @@ struct Server {
         return url
     }
     
+    func createSSESubscribeURL() -> String {
+        let baseURL = Server.baseURL
+        let chatsPath = Path.chats.rawValue
+        let subscribePath = Path.subscribe.rawValue
+        
+        let url = baseURL + chatsPath + subscribePath
+        return url
+    }
+    
     enum Query: String {
         case code = "code="
         case page = "page="

--- a/iOS/second-hand/second-hand/Network/SocketManager.swift
+++ b/iOS/second-hand/second-hand/Network/SocketManager.swift
@@ -17,7 +17,7 @@ class SocketManager {
         self.roomId = roomId
         self.sender = sender
         
-        guard let socketURL = URL(string: "ws://3.37.51.148:81/chat") else {
+        guard let socketURL = URL(string: "ws://43.202.132.236:81/chat") else {
             return
         }
         

--- a/iOS/second-hand/second-hand/SaleLog/Controller/SaleLogViewController.swift
+++ b/iOS/second-hand/second-hand/SaleLog/Controller/SaleLogViewController.swift
@@ -22,9 +22,9 @@ final class SaleLogViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(true)
-        setNavigationBar()
-        navigationController?.setNavigationBarHidden(false, animated: true)
         super.viewDidLoad()
+        //setNavigationBar()
+        navigationController?.setNavigationBarHidden(false, animated: true)
         self.view.backgroundColor = .white
         self.navigationItem.title = "판매 내역"
         items.removeAll()
@@ -38,6 +38,7 @@ final class SaleLogViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setNavigationBar()
         setupDataSource()
         setdelegate()
     }
@@ -59,7 +60,10 @@ final class SaleLogViewController: UIViewController {
         let borderView = UIView(frame: CGRect(x: .zero, y: navigationBar.frame.maxY, width: navigationBar.frame.width, height: 1))
         
         borderView.backgroundColor = UIColor.neutralBorder
-        navigationBar.addSubview(borderView)
+        
+        if !navigationBar.contains(borderView) {
+            navigationBar.addSubview(borderView)
+        }
     }
     
     @objc func segmentValueChanged(_ sender: UISegmentedControl) {

--- a/iOS/second-hand/second-hand/SaleLog/Controller/SaleLogViewController.swift
+++ b/iOS/second-hand/second-hand/SaleLog/Controller/SaleLogViewController.swift
@@ -138,7 +138,7 @@ final class SaleLogViewController: UIViewController {
             return
         }
         
-        NetworkManager.sendGET(decodeType: MyItemListSuccess.self, what: nil, fromURL: url) { (result: Result<[MyItemListSuccess], Error>) in
+        NetworkManager.sendGET(decodeType: MyItemListSuccess.self,header: nil, body: nil, fromURL: url) { (result: Result<[MyItemListSuccess], Error>) in
             switch result {
             case .success(let data):
                 guard let itemList = data.last else {
@@ -246,7 +246,7 @@ extension SaleLogViewController: MoreButtonTappedDelegate {
             guard let url = URL(string: Server.shared.itemDetailURL(itemId: id)) else {
                 return
             }
-            NetworkManager.sendGET(decodeType: ItemDetailInfoSuccess.self, what: nil, fromURL: url) { [self] (result: Result<[ItemDetailInfoSuccess], Error>) in
+            NetworkManager.sendGET(decodeType: ItemDetailInfoSuccess.self,header: nil, body: nil, fromURL: url) { [self] (result: Result<[ItemDetailInfoSuccess], Error>) in
                 switch result {
                 case .success(let data) :
                     guard let detailInfo = data.last?.data else {

--- a/iOS/second-hand/second-hand/WishListViewController.swift
+++ b/iOS/second-hand/second-hand/WishListViewController.swift
@@ -205,7 +205,7 @@ final class WishListViewController: NavigationUnderLineViewController, ButtonAct
             return
         }
         
-        NetworkManager.sendGET(decodeType: WishItemList.self, what: nil, fromURL: url) { [weak self] (result: Result<[WishItemList], Error>) in
+        NetworkManager.sendGET(decodeType: WishItemList.self,header: nil, body: nil, fromURL: url) { [weak self] (result: Result<[WishItemList], Error>) in
             switch result {
             case .success(let data):
                 guard let itemList = data.last else {
@@ -245,7 +245,7 @@ final class WishListViewController: NavigationUnderLineViewController, ButtonAct
             return
         }
         
-        NetworkManager.sendGET(decodeType: GetCategories.self, what: nil, fromURL: url) { [weak self] (result: Result<[GetCategories], Error>) in
+        NetworkManager.sendGET(decodeType: GetCategories.self,header: nil, body: nil, fromURL: url) { [weak self] (result: Result<[GetCategories], Error>) in
             switch result {
             case .success(let data):
                 guard let categories = data.last?.data.categories else {


### PR DESCRIPTION
## 주요작업 
- SSE서버 채팅알림 구독 요청 
   - GET 요청 메소드 수정 : header 파라미터 추가 
   - 채팅알림 구독요청 메소드 작성 
   
## 특이사항 

### ☠️ SSE 알림 구독 요청 에러

- API명세에 명시된대로 요청을 보냈으나 , 응답이 오지 않는 현상 발생
- BE와 함께 확인해본 결과 , 원인을 알 수 없는 에러임이 드러났다.
    - 에러 분석 
    - http GET요청을 보내면 , 실패를 했던 안했던 그 즉시 서버에 로그가 찍히는게 정상적인 흐름이다. 
    
    - 하지만 , 클라이언트측에서 요청을 보내고 , 요청 timeout이 다 흐르고 나서야 서버에 로그가 찍히고, 그에 대한 응답은 nil로 돌아온다.
        
        
        - 일단 60초가 지나도 서버에 도달하지 못하는 것 자체로도 문제가 있지만, 혹시나 좀 더 긴 타임아웃을 설정하면  정상응답이 오지 않을까 해서 5분으로 설정하고 요청을 해보아도, 5분이 다 소모된 뒤에 서버에 로그가 찍히고, 클라이언트에도 nil응답이 도착한다.
