### PR TITLE
iOS - 457 채팅룸 목록 시간순 정렬 기능 추가 

### DIFF
--- a/iOS/second-hand/second-hand/Chatting/Model/ChatroomListModel.swift
+++ b/iOS/second-hand/second-hand/Chatting/Model/ChatroomListModel.swift
@@ -79,13 +79,6 @@ class ChatroomListModel: Updatable {
                     return
                 }
                 completion(true)
-                //                if response.data.chatroomId == nil || response.data.opponentId == UserInfoManager.shared.userInfo?.memberId {
-                //                    completion(false)
-                //                    return
-                //                } else {
-                //                    completion(true)
-                //                }
-                
             case .failure(let error) :
                 print(error.localizedDescription)
                 completion(false)

--- a/iOS/second-hand/second-hand/Chatting/Model/ChatroomListModel.swift
+++ b/iOS/second-hand/second-hand/Chatting/Model/ChatroomListModel.swift
@@ -43,21 +43,21 @@ class ChatroomListModel: Updatable {
     
     private func sortList(list: [ChatroomList]) -> [ChatroomList] {
         let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withFractionalSeconds, .withDashSeparatorInDate, .withColonSeparatorInTime,.withFullDate,.withTime]
         
-        for chatroom in list {
-            
-        }
-        
-        let sortedList = list.sorted { (chatroom1, chatroom2) in
-            if let date1 = dateFormatter.date(from: chatroom1.lastUpdate),
-               let date2 = dateFormatter.date(from: chatroom2.lastUpdate) {
-                return date1 > date2
+        if list.count <= 1 {
+            return list
+        } else {
+            let sortedList = list.sorted { (chatroom1, chatroom2) in
+                if let date1 = dateFormatter.date(from: chatroom1.lastUpdate), let date2 = dateFormatter.date(from: chatroom2.lastUpdate) {
+                    return date1 > date2
+                } else {
+                    return false
+                }
             }
-            return false
+            return sortedList
         }
-        return sortedList
     }
-    
     private func isValidChatroom(chatroom: ChatroomList, completion: @escaping (Bool) -> Void) {
         let itemId = chatroom.item.itemId
         

--- a/iOS/second-hand/second-hand/Chatting/Model/ChatroomListModel.swift
+++ b/iOS/second-hand/second-hand/Chatting/Model/ChatroomListModel.swift
@@ -32,11 +32,30 @@ class ChatroomListModel: Updatable {
                     }
                     count += 1
                     if count == chatrooms.count {
+                        let sortedList = self.sortList(list: self.info)
+                        self.info = sortedList
                         completion()
                     }
                 }
             }
         }
+    }
+    
+    private func sortList(list: [ChatroomList]) -> [ChatroomList] {
+        let dateFormatter = ISO8601DateFormatter()
+        
+        for chatroom in list {
+            
+        }
+        
+        let sortedList = list.sorted { (chatroom1, chatroom2) in
+            if let date1 = dateFormatter.date(from: chatroom1.lastUpdate),
+               let date2 = dateFormatter.date(from: chatroom2.lastUpdate) {
+                return date1 > date2
+            }
+            return false
+        }
+        return sortedList
     }
     
     private func isValidChatroom(chatroom: ChatroomList, completion: @escaping (Bool) -> Void) {
@@ -60,12 +79,12 @@ class ChatroomListModel: Updatable {
                     return
                 }
                 completion(true)
-//                if response.data.chatroomId == nil || response.data.opponentId == UserInfoManager.shared.userInfo?.memberId {
-//                    completion(false)
-//                    return
-//                } else {
-//                    completion(true)
-//                }
+                //                if response.data.chatroomId == nil || response.data.opponentId == UserInfoManager.shared.userInfo?.memberId {
+                //                    completion(false)
+                //                    return
+                //                } else {
+                //                    completion(true)
+                //                }
                 
             case .failure(let error) :
                 print(error.localizedDescription)

--- a/iOS/second-hand/second-hand/Chatting/View/CellOfChatroomList.swift
+++ b/iOS/second-hand/second-hand/Chatting/View/CellOfChatroomList.swift
@@ -21,7 +21,7 @@ class CellOfChatroomList: UITableViewCell {
         
         setOpponentPhoto(img:chatroomList.opponent.profileImgUrl)
         
-        setTextSection(opponeneId: chatroomList.opponent.memberId, time: chatroomList.chatLogs.updatedAt ?? "", lastMessage: chatroomList.chatLogs.lastMessage ?? "")
+        setTextSection(opponeneId: chatroomList.opponent.memberId, time: chatroomList.chatLogs.updatedAt ?? "", lastMessage: chatroomList.chatLogs.lastMessage )
         
         setNumberBadge(number: chatroomList.chatLogs.unReadCount)
         

--- a/iOS/second-hand/second-hand/Network/CodableTemplate.swift
+++ b/iOS/second-hand/second-hand/Network/CodableTemplate.swift
@@ -275,6 +275,7 @@ struct ChatroomList: Codable {
     let opponent : ChatroomListOpponent
     let item : ChatroomListItem
     let chatLogs : ChatroomListChatLog
+    let lastUpdate : String
 }
 
 struct ChatroomListOpponent: Codable {

--- a/iOS/second-hand/second-hand/Network/MultipartTypeCreater.swift
+++ b/iOS/second-hand/second-hand/Network/MultipartTypeCreater.swift
@@ -22,11 +22,10 @@ class MultipartTypeCreater {
             let contentType = "Content-Type: image/jpeg\r\n\r\n"
             body.append(contentType.data(using: .utf8)!)
 
-            // 이미지 데이터를 추가
             body.append(imageData)
             
             body.append("\r\n".data(using: .utf8)!)
-            // 마지막 boundary 추가
+
             let finalBoundaryString = "--\(boundary)--\r\n"
             body.append(finalBoundaryString.data(using: .utf8)!)
         }


### PR DESCRIPTION
## 주요 작업 
- API 명세에 맞게 모델 수정 : lastUpdate 프로퍼티 추가 
- 채팅방 목록을 가장 최근에 업데이트된 시간을 기준으로 오름차순 정렬되게끔 추가 메소드 구현 
