### PR TITLE
iOS 460 - ItemDetailView 개선 

### DIFF
--- a/iOS/second-hand/second-hand.xcodeproj/project.pbxproj
+++ b/iOS/second-hand/second-hand.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		E45BF67A2A7649FD0026AD03 /* MyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E45BF6792A7649FD0026AD03 /* MyCell.swift */; };
 		E45BF67C2A765BF20026AD03 /* MyBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = E45BF67B2A765BF20026AD03 /* MyBubble.swift */; };
 		E45BF67E2A78FD830026AD03 /* PrivateChatroomChattingLogModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E45BF67D2A78FD830026AD03 /* PrivateChatroomChattingLogModel.swift */; };
+		E466677F2AFA34490040C5CB /* UIScrollView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E466677E2AFA34490040C5CB /* UIScrollView+Extension.swift */; };
 		E467380D2A440D0E006A46D1 /* UserInfoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E467380C2A440D0E006A46D1 /* UserInfoManager.swift */; };
 		E467380F2A453FBF006A46D1 /* Server.swift in Sources */ = {isa = PBXBuildFile; fileRef = E467380E2A453FBF006A46D1 /* Server.swift */; };
 		E46738112A482DF1006A46D1 /* Updatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46738102A482DF1006A46D1 /* Updatable.swift */; };
@@ -142,6 +143,7 @@
 		E45BF6792A7649FD0026AD03 /* MyCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCell.swift; sourceTree = "<group>"; };
 		E45BF67B2A765BF20026AD03 /* MyBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyBubble.swift; sourceTree = "<group>"; };
 		E45BF67D2A78FD830026AD03 /* PrivateChatroomChattingLogModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateChatroomChattingLogModel.swift; sourceTree = "<group>"; };
+		E466677E2AFA34490040C5CB /* UIScrollView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+Extension.swift"; sourceTree = "<group>"; };
 		E467380C2A440D0E006A46D1 /* UserInfoManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoManager.swift; sourceTree = "<group>"; };
 		E467380E2A453FBF006A46D1 /* Server.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Server.swift; sourceTree = "<group>"; };
 		E46738102A482DF1006A46D1 /* Updatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Updatable.swift; sourceTree = "<group>"; };
@@ -440,6 +442,7 @@
 				DB55CB122A44186E00578ED5 /* UITextField+Extension.swift */,
 				E4987E442A4D9F7600337543 /* Int,String+Extension.swift */,
 				DBCD32192A80E3EB00F58AC0 /* Array+Extension.swift */,
+				E466677E2AFA34490040C5CB /* UIScrollView+Extension.swift */,
 			);
 			path = UIExtensions;
 			sourceTree = "<group>";
@@ -1007,6 +1010,7 @@
 				DBAF838A2A32B7CA00194A02 /* NavigationUnderLineViewController.swift in Sources */,
 				E49EB8362A2DC207001F2D56 /* TabBarItem.swift in Sources */,
 				DBB04D2D2A2DA5BF001233CC /* SceneDelegate.swift in Sources */,
+				E466677F2AFA34490040C5CB /* UIScrollView+Extension.swift in Sources */,
 				DBAF83B12A32E3E900194A02 /* IdStackView.swift in Sources */,
 				DB08D4482A4BFC6F00D45E32 /* UIStackView+extension.swift in Sources */,
 				DB51AD9C2A5A9E5D00EB939D /* AddPhotoImageView.swift in Sources */,
@@ -1088,7 +1092,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1142,7 +1146,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;

--- a/iOS/second-hand/second-hand/Home/subScene/ItemDetail/Controller/ItemDetailViewController.swift
+++ b/iOS/second-hand/second-hand/Home/subScene/ItemDetail/Controller/ItemDetailViewController.swift
@@ -47,6 +47,22 @@ class ItemDetailViewController: UIViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         bringButtonsToFront()
+        updateContentSize()
+    }
+    
+    func updateContentSize() {
+        if textSectionView == nil {
+            return
+        }
+        
+        if textSectionView.contentOfPost == nil {
+            return
+        }
+
+        if textSectionView.contentOfPost!.frame.height == .zero {
+            return
+        }
+        self.textSectionView.updateContentSize()
     }
     
     func updateStatusDelegateIfNeeded() {
@@ -381,9 +397,9 @@ class ItemDetailViewController: UIViewController {
         NSLayoutConstraint.activate(
             [
                 textSectionView.topAnchor.constraint(equalTo: self.view.centerYAnchor, constant: 10.0),
-                textSectionView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor,constant: -50),
                 textSectionView.widthAnchor.constraint(equalTo: self.view.widthAnchor),
-                textSectionView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
+                textSectionView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+                textSectionView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: -50.0)
             ]
         )
     }

--- a/iOS/second-hand/second-hand/Home/subScene/ItemDetail/Controller/ItemDetailViewController.swift
+++ b/iOS/second-hand/second-hand/Home/subScene/ItemDetail/Controller/ItemDetailViewController.swift
@@ -101,7 +101,7 @@ class ItemDetailViewController: UIViewController {
             return
         }
         
-
+        
         let group = DispatchGroup()
         
         group.enter()
@@ -111,7 +111,7 @@ class ItemDetailViewController: UIViewController {
             defer {
                 group.leave()
             }
-
+            
             switch result {
             case .success(let data):
                 guard let detailInfo = data.last else {

--- a/iOS/second-hand/second-hand/Home/subScene/ItemDetail/VIew/ContentOfPost.swift
+++ b/iOS/second-hand/second-hand/Home/subScene/ItemDetail/VIew/ContentOfPost.swift
@@ -33,11 +33,11 @@ class ContentOfPost: UIView {
         let contentWidth = bounds.width
         let titleHeight = titleLabel.intrinsicContentSize.height
         let categoryHeight = categotyAndCreateAtLabel.intrinsicContentSize.height
-        let descriptionHeight = descriptionView.intrinsicContentSize.height
+        let descriptionHeight = calculateTextBoxHeight(for: .systemFont(ofSize: 15.0), text: descriptionView.text, maxWidth: Utils.screenWidth() * 0.95) + descriptionView.intrinsicContentSize.height
         let countHeight = countsLabel.intrinsicContentSize.height
         
-        let totalHeight = titleHeight + categoryHeight + descriptionHeight + countHeight + 30 
-
+        let totalHeight = titleHeight + categoryHeight + descriptionHeight + countHeight + 30.0
+        
         return CGSize(width: contentWidth, height: totalHeight)
     }
     
@@ -59,8 +59,8 @@ class ContentOfPost: UIView {
         setCategotyAndCreateAtLabelConstraints()
         setDescriptionViewConstraints()
         setCountLabelConstraints()
-        invalidateIntrinsicContentSize()
     }
+    
     // MARK: TITLE
     
     private func setTitleLabel(title: String) {
@@ -155,7 +155,6 @@ class ContentOfPost: UIView {
     
     private func setDescriptionView(content: String) {
         self.descriptionView = UITextView(frame: .zero)
-        
         self.descriptionView?.text = content
         self.descriptionView?.textAlignment = .left
         self.descriptionView?.font = .systemFont(ofSize: 15.0)
@@ -167,10 +166,6 @@ class ContentOfPost: UIView {
             return
         }
         
-        guard let text = descriptionView.text else {
-            return
-        }
-        
         guard let standard = categotyAndCreateAtLabel?.bottomAnchor else {
             return
         }
@@ -179,20 +174,25 @@ class ContentOfPost: UIView {
             self.addSubview(descriptionView)
         }
         
-        let lineCount = text.components(separatedBy: "\n").count
-        
-        let height = CGFloat((lineCount+(text.count / 25)) * 30)
-        
         descriptionView.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate(
             [
                 descriptionView.topAnchor.constraint(equalTo: standard ,constant: 10.0),
-                descriptionView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: -5.0),
-                descriptionView.widthAnchor.constraint(equalTo: self.widthAnchor),
-                descriptionView.heightAnchor.constraint(equalToConstant: height)
+                descriptionView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+                descriptionView.widthAnchor.constraint(equalTo: self.widthAnchor)
             ]
         )
+    }
+    
+    private func calculateTextBoxHeight(for font: UIFont, text: String, maxWidth: CGFloat) -> CGFloat{
+        let boundingSize = CGSize(width: maxWidth, height: .greatestFiniteMagnitude)
+        let options: NSStringDrawingOptions = [.usesLineFragmentOrigin, .usesFontLeading]
+        
+        let attributes: [NSAttributedString.Key: Any] = [.font: font]
+        let boundingRect = text.boundingRect(with: boundingSize, options: options, attributes: attributes, context: nil)
+        
+        return boundingRect.height
     }
     
     // MARK: countsLabel

--- a/iOS/second-hand/second-hand/Home/subScene/ItemDetail/VIew/ItemDetailTextSectionView.swift
+++ b/iOS/second-hand/second-hand/Home/subScene/ItemDetail/VIew/ItemDetailTextSectionView.swift
@@ -22,15 +22,11 @@ class ItemDetailTextSectionView: UIScrollView {
     
     override func layoutSubviews() {
         super.layoutSubviews()
-        
-        self.contentSize = CGSize(width: self.frame.width, height: contentOfPost.intrinsicContentSize.height + sellerInfoView.frame.height + statusButton.frame.height + 40)
-        invalidateIntrinsicContentSize()
         setSellerInfoConstraints()
         setStatusButtonConstraints()
         setContenetOfPostConstraints()
     }
-    
-    
+
     
     // MARK: SELLER INFO VIEW
     func setSellerInfoView(sellerName: String) {

--- a/iOS/second-hand/second-hand/Home/subScene/ItemDetail/VIew/ItemDetailTextSectionView.swift
+++ b/iOS/second-hand/second-hand/Home/subScene/ItemDetail/VIew/ItemDetailTextSectionView.swift
@@ -119,20 +119,19 @@ class ItemDetailTextSectionView: UIScrollView {
         
         if self.subviews.contains(statusButton) {
             NSLayoutConstraint.activate(
-                [
+                [   contentOfPost.leadingAnchor.constraint(equalTo: self.leadingAnchor,constant: 10.0),
+                    contentOfPost.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -10.0),
                     contentOfPost.topAnchor.constraint(equalTo: statusButton.bottomAnchor, constant: 10),
-                    contentOfPost.widthAnchor.constraint(equalTo: self.widthAnchor, constant: -30.0),
-                    contentOfPost.heightAnchor.constraint(equalToConstant: self.contentSize.height),
                     contentOfPost.centerXAnchor.constraint(equalTo: self.centerXAnchor)
                 ]
             )
         } else {
             NSLayoutConstraint.activate(
                 [
+                    contentOfPost.leadingAnchor.constraint(equalTo: self.leadingAnchor,constant: 10.0),
+                    contentOfPost.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -10.0),
                     contentOfPost.topAnchor.constraint(equalTo: sellerInfoView.bottomAnchor, constant: 10),
-                    contentOfPost.widthAnchor.constraint(equalTo: self.widthAnchor, constant: -30.0),
-                    contentOfPost.centerXAnchor.constraint(equalTo: self.centerXAnchor),
-                    contentOfPost.heightAnchor.constraint(equalToConstant: contentOfPost.intrinsicContentSize.height)
+                    contentOfPost.centerXAnchor.constraint(equalTo: self.centerXAnchor)
                 ]
             )
         }

--- a/iOS/second-hand/second-hand/Network/SocketManager.swift
+++ b/iOS/second-hand/second-hand/Network/SocketManager.swift
@@ -31,7 +31,7 @@ class SocketManager {
         self.socketClient?.delegate = self
         self.socketClient?.autoReconnect = true
         self.socketClient?.enableLogging = true
-        //self.socketClient?.connect(loginToken: loginToken)
+        self.socketClient?.connect(loginToken: loginToken)
         
     }
     

--- a/iOS/second-hand/second-hand/UIExtensions/UIScrollView+Extension.swift
+++ b/iOS/second-hand/second-hand/UIExtensions/UIScrollView+Extension.swift
@@ -1,0 +1,35 @@
+//
+//  UIScrollView=Extension.swift
+//  second-hand
+//
+//  Created by SONG on 2023/11/07.
+//
+
+import UIKit
+
+extension UIScrollView {
+    func updateContentSize() {
+        let unionCalculatedTotalRect = recursiveUnionInDepthFor(view: self)
+
+        self.contentSize = CGSize(width: self.frame.width, height: unionCalculatedTotalRect.height)
+    }
+    
+    private func recursiveUnionInDepthFor(view: UIView) -> CGRect {
+        var totalRect: CGRect = .zero
+
+        for subview in view.subviews {
+            if ((subview as? StatusButton) != nil) {
+                print("StatusButton \(subview.frame)")
+                totalRect = totalRect.union(recursiveUnionInDepthFor(view: subview))
+            } else if ((subview as? SellerInfoView) != nil) {
+                print("SellerInfoView \(subview.frame)")
+                totalRect = totalRect.union(recursiveUnionInDepthFor(view: subview))
+            } else if ((subview as? ContentOfPost) != nil) {
+                print("ContentOfPost \(subview.frame)")
+                totalRect = totalRect.union(recursiveUnionInDepthFor(view: subview))
+            }
+        }
+        print("한사이클 끝 \(totalRect.union(view.frame).size)")
+        return totalRect.union(view.frame)
+    }
+}

--- a/iOS/second-hand/second-hand/UIExtensions/UIScrollView+Extension.swift
+++ b/iOS/second-hand/second-hand/UIExtensions/UIScrollView+Extension.swift
@@ -9,27 +9,23 @@ import UIKit
 
 extension UIScrollView {
     func updateContentSize() {
-        let unionCalculatedTotalRect = recursiveUnionInDepthFor(view: self)
+        let height = calculateHeight(view: self)
 
-        self.contentSize = CGSize(width: self.frame.width, height: unionCalculatedTotalRect.height)
+        self.contentSize = CGSize(width: self.frame.width, height: height)
     }
     
-    private func recursiveUnionInDepthFor(view: UIView) -> CGRect {
-        var totalRect: CGRect = .zero
+    private func calculateHeight(view: UIView) -> CGFloat {
+        var totalHeight: CGFloat = .zero
 
         for subview in view.subviews {
             if ((subview as? StatusButton) != nil) {
-                print("StatusButton \(subview.frame)")
-                totalRect = totalRect.union(recursiveUnionInDepthFor(view: subview))
+                totalHeight += subview.frame.height
             } else if ((subview as? SellerInfoView) != nil) {
-                print("SellerInfoView \(subview.frame)")
-                totalRect = totalRect.union(recursiveUnionInDepthFor(view: subview))
+                totalHeight += subview.frame.height
             } else if ((subview as? ContentOfPost) != nil) {
-                print("ContentOfPost \(subview.frame)")
-                totalRect = totalRect.union(recursiveUnionInDepthFor(view: subview))
+                totalHeight += subview.frame.height
             }
         }
-        print("한사이클 끝 \(totalRect.union(view.frame).size)")
-        return totalRect.union(view.frame)
+        return totalHeight
     }
 }


### PR DESCRIPTION
## 주요작업 
상품상세 화면 개선 
- 텍스트 박스 크기에 따른 height 동적 변화 적용 
- 내부 subviews 들의 길이에 맞게 contentSize 재조정

## 상세 설명 
 - ContentOfPost 의 Intrinsic Content Size를 재정의 하였음.
 - 기존의 글자수 기반으로 하는 레이아웃 설정 방식을 버리고 , 텍스트 폰트와 길이를 고려하여 텍스트박스의 크기를 정확하게 계산 후에 view에 반영하는 방식으로 변경
 - 기존의 글자수가 길어지면 레이아웃이 깨지는 현상 수정 , 스크롤 범위 또한 내부 view들의 크기에 맞게 동적으로 할당됨.