### PR TITLE
[#467]refactor: styled components prop 명 수정

### DIFF
--- a/front-end/src/components/common/Button/Button.tsx
+++ b/front-end/src/components/common/Button/Button.tsx
@@ -7,8 +7,8 @@ interface ButtonProps extends ComponentPropsWithRef<'button'> {
   category?: boolean;
   icon?: boolean;
   circle?: 'sm' | 'md' | 'lg';
-  fullWidth?: boolean;
-  spaceBetween?: boolean;
+  stretch?: boolean;
+  gapped?: boolean;
   disabled?: boolean;
   children?: ReactNode;
 }
@@ -18,7 +18,7 @@ interface Circle {
 }
 
 interface ButtonStyleProps extends ButtonProps {
-  circleSize?: number;
+  size?: number;
   children?: ReactNode;
 }
 
@@ -29,8 +29,8 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       category = false,
       icon = false,
       circle,
-      fullWidth = false,
-      spaceBetween = false,
+      stretch = false,
+      gapped = false,
       disabled = false,
       children,
       ...rest
@@ -38,14 +38,14 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     ref,
   ) => {
     const circleTypes = (circle: keyof Circle) => {
-      const circleSize: Circle = {
+      const size: Circle = {
         sm: 20,
         md: 28,
         lg: 56,
       };
 
       if (circle) {
-        return circleSize[circle];
+        return size[circle];
       }
     };
 
@@ -54,9 +54,9 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         active={active}
         category={category}
         icon={icon}
-        circleSize={circle && circleTypes(circle)}
-        fullWidth={fullWidth}
-        spaceBetween={spaceBetween}
+        size={circle && circleTypes(circle)}
+        stretch={stretch}
+        gapped={gapped}
         disabled={disabled}
         ref={ref}
         {...rest}
@@ -92,11 +92,11 @@ const MyButton = styled.button<ButtonStyleProps>`
       border: none;
       gap: 7px;
     `}
-  ${({ circleSize, theme }) =>
-    circleSize &&
+  ${({ size, theme }) =>
+    size &&
     css`
-      height: ${circleSize}px;
-      width: ${circleSize}px;
+      height: ${size}px;
+      width: ${size}px;
       ${theme.fonts.caption2};
       border-radius: 50%;
       padding: 10px;
@@ -106,15 +106,15 @@ const MyButton = styled.button<ButtonStyleProps>`
     css`
       border-radius: 50px;
     `}
-  ${({ fullWidth, theme }) =>
-    fullWidth &&
+  ${({ stretch, theme }) =>
+    stretch &&
     css`
       width: 100%;
       padding: 16px 20px;
       ${theme.fonts.subhead};
     `}
-  ${({ spaceBetween }) =>
-    spaceBetween &&
+  ${({ gapped }) =>
+    gapped &&
     css`
       justify-content: space-between;
     `}

--- a/front-end/src/components/common/ImgBox/ImgBox.tsx
+++ b/front-end/src/components/common/ImgBox/ImgBox.tsx
@@ -9,7 +9,7 @@ interface ImgBoxProps extends ComponentPropsWithRef<'img'> {
 }
 
 interface ImgBoxStyleProps {
-  boxSize: number;
+  size: number;
 }
 
 const ImgBox = ({ src, alt, size = 'lg' }: ImgBoxProps) => {
@@ -21,15 +21,15 @@ const ImgBox = ({ src, alt, size = 'lg' }: ImgBoxProps) => {
   const boxSize = boxType[size];
 
   return (
-    <MyImgBox boxSize={boxSize}>
+    <MyImgBox size={boxSize}>
       <MyImg src={src} alt={alt} />
     </MyImgBox>
   );
 };
 
 const MyImgBox = styled.div<ImgBoxStyleProps>`
-  width: ${({ boxSize }) => boxSize}px;
-  height: ${({ boxSize }) => boxSize}px;
+  width: ${({ size }) => size}px;
+  height: ${({ size }) => size}px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/front-end/src/components/common/PopupSheet/PopupSheet.tsx
+++ b/front-end/src/components/common/PopupSheet/PopupSheet.tsx
@@ -13,7 +13,7 @@ interface PopupSheetProps {
 }
 
 interface PopupSheetStyleProps {
-  isSlideDown?: boolean;
+  dropped?: boolean;
 }
 
 interface OptionStyleProps extends PopupSheetStyleProps {
@@ -27,7 +27,7 @@ const PopupSheet = ({
 }: PopupSheetProps) => {
   return (
     <>
-      <MyPopupSheetBackground isSlideDown={isSlideDown} onClick={onClick} />
+      <MyPopupSheetBackground dropped={isSlideDown} onClick={onClick} />
       <SlideSheet isSlideDown={isSlideDown} menu={menu} onClick={onClick} />
     </>
   );
@@ -35,16 +35,13 @@ const PopupSheet = ({
 
 const SlideSheet = ({ isSlideDown, menu, onClick }: PopupSheetProps) => {
   return (
-    <MyMenuPopupSheet isSlideDown={isSlideDown}>
-      <MySlideSheet
-        isSlideDown={isSlideDown}
-        onClick={(e) => e.stopPropagation()}
-      >
+    <MyMenuPopupSheet dropped={isSlideDown}>
+      <MySlideSheet dropped={isSlideDown} onClick={(e) => e.stopPropagation()}>
         {menu.map(({ id, title, style, onClick }) => (
           <MyPopupOption
             key={id}
             option={style}
-            isSlideDown={isSlideDown}
+            dropped={isSlideDown}
             onClick={onClick}
           >
             {title}
@@ -63,8 +60,8 @@ const MyPopupSheetBackground = styled.div<PopupSheetStyleProps>`
   left: 0;
   width: 100%;
   height: 100vh;
-  ${({ isSlideDown, theme }) =>
-    isSlideDown
+  ${({ dropped, theme }) =>
+    dropped
       ? css`
           opacity: 0;
         `
@@ -77,8 +74,8 @@ const MySlideSheet = styled.div<PopupSheetStyleProps>`
   display: flex;
   flex-direction: column;
   border-radius: 12px;
-  ${({ isSlideDown }) =>
-    isSlideDown
+  ${({ dropped }) =>
+    dropped
       ? css`
           z-index: 10;
           position: absolute;
@@ -94,8 +91,8 @@ const MySlideSheet = styled.div<PopupSheetStyleProps>`
 `;
 
 const MyMenuPopupSheet = styled.div<PopupSheetStyleProps>`
-  ${({ isSlideDown }) =>
-    !isSlideDown &&
+  ${({ dropped }) =>
+    !dropped &&
     css`
       z-index: 10;
       position: absolute;
@@ -118,8 +115,8 @@ const MyCancelButton = styled.button`
 `;
 
 const MyPopupOption = styled.button<OptionStyleProps>`
-  ${({ isSlideDown }) =>
-    isSlideDown
+  ${({ dropped }) =>
+    dropped
       ? css`
           height: 45px;
           line-height: 45px;

--- a/front-end/src/components/common/SegmentedControl/SegmentedControl.tsx
+++ b/front-end/src/components/common/SegmentedControl/SegmentedControl.tsx
@@ -6,8 +6,8 @@ interface SegmentedControlProps {
   onClick: (status: number) => void;
 }
 
-interface SelectedBarProps {
-  selectedIndex: number;
+interface SelectionBarProps {
+  selection: number;
 }
 
 const SegmentedControl = ({
@@ -17,7 +17,7 @@ const SegmentedControl = ({
 }: SegmentedControlProps) => {
   return (
     <MySegmentedControl>
-      <MySelectedBar selectedIndex={value} />
+      <MySelectionBar selection={value} />
       {options.map(({ status, label }, index) => (
         <MySegmentedButton key={status} onClick={() => onClick(index)}>
           {label}
@@ -40,11 +40,11 @@ const MySegmentedControl = styled.div`
   border-radius: 8px;
 `;
 
-const MySelectedBar = styled.div<SelectedBarProps>`
+const MySelectionBar = styled.div<SelectionBarProps>`
   position: absolute;
   width: 48%;
   height: 89%;
-  left: ${({ selectedIndex }) => selectedIndex * 50 + 1}%;
+  left: ${({ selection }) => selection * 50 + 1}%;
   transition: left 0.3s ease-in-out;
   background-color: ${({ theme }) => theme.colors.accent.text};
   border: 0.5px solid ${({ theme }) => theme.colors.neutral.border};


### PR DESCRIPTION
## 작업 내용
- styled component에 prop을 넘기는 경우 카멜케이스의 prop명에서 Warning이 발생 (대문자 사용 이슈)
- 카멜케이스의 prop명을 대문자를 포함하지 않는 하나의 단어 하나로 수정